### PR TITLE
Convert to ocaml-migrate-parsetree + ppx_tools_versioned

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,5 +1,7 @@
-true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string, cppo_V_OCAML
+true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string
 
 "src": include
-<src/*.{ml,mli,byte,native}>: package(ppx_tools.metaquot), package(ppx_deriving.api), package(result)
+<src/*.{ml,mli,byte,native}>: package(ppx_tools_versioned.metaquot_405), \
+  package(ppx_deriving.api), package(result), \
+  package(ocaml-migrate-parsetree), package(ppx_tools_versioned)
 <src_test/*.{ml,byte,native}>: debug, package(result), package(oUnit), package(yojson), use_yojson

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -1,7 +1,6 @@
 open Ocamlbuild_plugin
 
 let () = dispatch (fun phase ->
-  Ocamlbuild_cppo.dispatcher phase;
   match phase with
   | After_rules ->
     let ppx_deriving_component deriver =

--- a/opam
+++ b/opam
@@ -20,9 +20,10 @@ build-test: [
 depends: [
   "yojson"
   "result"
+  "ppx_tools_versioned"
+  "ocaml-migrate-parsetree"
   "ppx_deriving" {>= "4.0" & < "5.0"}
   "ocamlfind"    {build}
-  "cppo"         {build}
   "ounit"        {test}
   "ppx_import"   {test & >= "1.1"}
 ]

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -3,7 +3,7 @@
 #use "topkg.ml"
 
 let ocamlbuild =
-  "ocamlbuild -use-ocamlfind -classic-display -plugin-tag 'package(cppo_ocamlbuild)'"
+  "ocamlbuild -use-ocamlfind -classic-display"
 
 let () =
   Pkg.describe "ppx_deriving_yojson" ~builder:(`Other (ocamlbuild, "_build")) [


### PR DESCRIPTION
This PR makes ppx_deriving_yojson build with the development version of ppx_deriving.

It seems to me that we 'd need something like `Ppx_deriving.Helpers_405` to be independant of the version of the AST used by ppx_deriving. In the meantime I've added a small overlay at the beginning of `ppx_deriving_yojson.ml` to get it to build.