### PR TITLE
Suppress warning 39 in generated code

### DIFF
--- a/opam
+++ b/opam
@@ -20,7 +20,7 @@ build-test: [
 depends: [
   "yojson"
   "result"
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "4.2" & < "5.0"}
   "ocamlfind"    {build}
   "cppo"         {build}
   "ounit"        {test}

--- a/src/ppx_deriving_yojson.cppo.ml
+++ b/src/ppx_deriving_yojson.cppo.ml
@@ -681,11 +681,18 @@ let sig_of_type_ext ~options ~path type_ext =
   (ser_sig_of_type_ext ~options ~path type_ext) @
   (desu_sig_of_type_ext ~options ~path type_ext)
 
+let suppress_warnings str =
+  let attr = Str.attribute @@ Ppx_deriving.attr_warning [%expr "-39"] in
+  [Str.include_ (Incl.mk (Mod.structure (attr::str)))]
+
 let structure f ~options ~path type_ =
   let (pre, vals) = f ~options ~path type_ in
-  match vals with
-  | [] -> pre
-  | _  -> pre @ [Str.value ?loc:None Recursive vals]
+  let inner =
+    match vals with
+    | [] -> pre
+    | _  -> pre @ [Str.value ?loc:None Recursive vals]
+  in
+  suppress_warnings inner
 
 let on_str_decls f ~options ~path type_decls =
   let (pre, vals) = List.split (List.map (f ~options ~path) type_decls) in


### PR DESCRIPTION
Hi,

This adds a way to suppress warnings in generated code - in particular warning 39 (see #21). It does so by wrapping generated code with:

```ocaml
include struct
  [@@@ warning "-39"]

  (* generated code here *)
end
```

Thanks!