### PR TITLE
Pass linkall flag

### DIFF
--- a/_tags
+++ b/_tags
@@ -3,3 +3,4 @@ true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string, cppo_V_OCAM
 "src": include
 <src/*.{ml,mli,byte,native}>: package(ppx_tools.metaquot), package(ppx_deriving.api), package(result)
 <src_test/*.{ml,byte,native}>: debug, package(result), package(oUnit), package(yojson), use_yojson
+true: linkall


### PR DESCRIPTION
This fixes the compatibility with ppx_deriving.4.2, as suggested in #49.