### PR TITLE
Add type annotations for `to_yojson` functions

### DIFF
--- a/src/ppx_deriving_yojson.cppo.ml
+++ b/src/ppx_deriving_yojson.cppo.ml
@@ -51,11 +51,11 @@ let rec ser_expr_of_typ typ =
     match attr_int_encoding typ with `String -> "String" | `Int -> "Intlit"
   in
   match typ with
-  | [%type: unit]            -> [%expr fun x -> `Null]
-  | [%type: int]             -> [%expr fun x -> `Int x]
-  | [%type: float]           -> [%expr fun x -> `Float x]
-  | [%type: bool]            -> [%expr fun x -> `Bool x]
-  | [%type: string]          -> [%expr fun x -> `String x]
+  | [%type: unit]            -> [%expr fun (x:Ppx_deriving_runtime.unit) -> `Null]
+  | [%type: int]             -> [%expr fun (x:Ppx_deriving_runtime.int) -> `Int x]
+  | [%type: float]           -> [%expr fun (x:Ppx_deriving_runtime.float) -> `Float x]
+  | [%type: bool]            -> [%expr fun (x:Ppx_deriving_runtime.bool) -> `Bool x]
+  | [%type: string]          -> [%expr fun (x:Ppx_deriving_runtime.string) -> `String x]
   | [%type: bytes]           -> [%expr fun x -> `String (Bytes.to_string x)]
   | [%type: char]            -> [%expr fun x -> `String (String.make 1 x)]
   | [%type: [%t? typ] ref]   -> [%expr fun x -> [%e ser_expr_of_typ typ] !x]

--- a/src_test/test_ppx_yojson.cppo.ml
+++ b/src_test/test_ppx_yojson.cppo.ml
@@ -375,6 +375,16 @@ let test_recursive ctxt =
   assert_roundtrip pp_bar bar_to_yojson bar_of_yojson
                    {lhs="x"; rhs=42} "{\"lhs\":\"x\",\"rhs\":42}"
 
+let test_int_redefined ctxt =
+  let module M = struct
+    type int = Break_things
+
+    let x = [%to_yojson: int] 1
+  end
+  in
+  let expected = `Int 1 in
+  assert_equal ~ctxt ~printer:show_json expected M.x
+
 let suite = "Test ppx_yojson" >::: [
     "test_unit"      >:: test_unit;
     "test_int"       >:: test_int;
@@ -406,6 +416,7 @@ let suite = "Test ppx_yojson" >::: [
     "test_nostrict"  >:: test_nostrict;
     "test_opentype"  >:: test_opentype;
     "test_recursive" >:: test_recursive;
+    "test_int_redefined" >:: test_int_redefined;
   ]
 
 let _ =


### PR DESCRIPTION
Previously, the generated functions for `[%to_yojson: int]` (and others) did not have a type annotation. Since the yojson types are polymorphic variants, this can be confusing since there is no type error, but the resulting type does not match `Yojson.Safe.json` (see #52).

I have two remarks on that patch:
- I'm not sure whether to add a `x:unit` annotation to the `unit` case - the value is not used so there is no risk of building an ill-typed yojson value. On the other hand, this keeps `[%to_yojson: unit]` polymorphic.
- I don't know if it is necessary to sanitize the `int`, `float`, etc references through a quoter a similar.

Thanks!