### PR TITLE
4.06 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: c
 env:
   - OCAML=4.02.3
   - OCAML=4.03.0
+  - OCAML=4.04.2
+  - OCAML=4.05.0
+  - OCAML=4.06.0
 script:
   - echo "yes" | sudo add-apt-repository ppa:avsm/ppa
   - sudo apt-get update -qq


### PR DESCRIPTION
I tested on top of https://github.com/ocaml-ppx/ppx_deriving/pull/159 (not merged in ppx_deriving yet), this should be the only additional change required for ppx_deriving_yojson to work under 4.06.

This is an alternative to https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/64, which is a sensibly more invasive change.