### PR TITLE
Added deriver option fields to generate key fields module

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,6 @@ Record variants are currently not supported for extensible variant types.
 
 By default, objects are deserialized strictly; that is, all keys in the object have to correspond to fields of the record. Passing `strict = false` as an option to the deriver  (i.e. `[@@deriving yojson { strict = false }]`) changes the behavior to ignore any unknown fields.
 
-#### Optional fields module
-Sometimes a list of JSON key names is useful, especially when using the `[@key ...]` feature (see the options section).
-This is supported via the `fields` deriver option,  eg. `[@@deriving yojson { fields = true }]`.
-When enabled the `Yosjon_fields_ty` module is created containing the value `keys` which as a `string list` of JSON keys.
-Note that if `ty` is `t` then the module is called `Yosjon_fields` instead
-
 ### Options
 
 Option attribute names may be prefixed with `yojson.` to avoid conflicts with other derivers.
@@ -137,6 +131,30 @@ type pagination = {
 ```
 
 Fields with default values are not required to be present in inputs and will not be emitted in outputs.
+
+#### `Yojson_fields` module
+
+The `fields` deriver option can be used to generate a module containing all JSON key names, e.g.
+
+```ocaml
+type foo = {
+ fvalue : float;
+ svalue : string [@key "@svalue_json"];
+ ivalue : int;
+} [@@deriving to_yojson { strict = false, fields = true } ]
+end
+```
+
+defines the following module:
+
+```ocaml
+module Yojson_fields_foo = struct
+  let keys = ["fvalue"; "@svalue_json"; "ivalue"] 
+  let _ = keys 
+end
+```
+
+When the type is named `t`, the module is named just `Yojson_fields`.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ type pagination = {
 
 Fields with default values are not required to be present in inputs and will not be emitted in outputs.
 
-#### `Yojson_fields` module
+#### `Yojson_meta` module
 
-The `fields` deriver option can be used to generate a module containing all JSON key names, e.g.
+The `meta` deriver option can be used to generate a module containing all JSON key names, e.g.
 
 ```ocaml
 type foo = {
@@ -148,13 +148,13 @@ end
 defines the following module:
 
 ```ocaml
-module Yojson_fields_foo = struct
+module Yojson_meta_foo = struct
   let keys = ["fvalue"; "@svalue_json"; "ivalue"] 
   let _ = keys 
 end
 ```
 
-When the type is named `t`, the module is named just `Yojson_fields`.
+When the type is named `t`, the module is named just `Yojson_meta`.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ Record variants are currently not supported for extensible variant types.
 
 By default, objects are deserialized strictly; that is, all keys in the object have to correspond to fields of the record. Passing `strict = false` as an option to the deriver  (i.e. `[@@deriving yojson { strict = false }]`) changes the behavior to ignore any unknown fields.
 
+#### Optional fields module
+Sometimes a list of JSON key names is useful, especially when using the `[@key ...]` feature (see the options section).
+This is supported via the `fields` deriver option,  eg. `[@@deriving yojson { fields = true }]`.
+When enabled the `Yosjon_fields_ty` module is created containing the value `keys` which as a `string list` of JSON keys.
+Note that if `ty` is `t` then the module is called `Yosjon_fields` instead
+
 ### Options
 
 Option attribute names may be prefixed with `yojson.` to avoid conflicts with other derivers.

--- a/src/ppx_deriving_yojson.cppo.ml
+++ b/src/ppx_deriving_yojson.cppo.ml
@@ -46,13 +46,13 @@ let attr_default attrs =
 
 let parse_options options =
   let strict = ref true in
-  let fields = ref false in
+  let meta = ref false in
   options |> List.iter (fun (name, expr) ->
     match name with
     | "strict" -> strict := Ppx_deriving.Arg.(get_expr ~deriver bool) expr
-    | "fields" -> fields := Ppx_deriving.Arg.(get_expr ~deriver bool) expr
+    | "meta" -> meta := Ppx_deriving.Arg.(get_expr ~deriver bool) expr
     | _ -> raise_errorf ~loc:expr.pexp_loc "%s does not support option %s" deriver name);
-  (!strict, !fields)
+  (!strict, !meta)
 
 let rec ser_expr_of_typ typ =
   let attr_int_encoding typ =
@@ -706,8 +706,8 @@ let desu_sig_of_type ~options ~path type_decl =
 let desu_sig_of_type_ext ~options ~path type_ext = []
 
 let yojson_str_fields ~options ~path ({ ptype_loc = loc } as type_decl) =
-  let (_, want_fields) =  parse_options options in
-  match want_fields, type_decl.ptype_kind with
+  let (_, want_meta) =  parse_options options in
+  match want_meta, type_decl.ptype_kind with
   | false, _ | true, Ptype_open -> []
   | true, kind ->
     match kind, type_decl.ptype_manifest with
@@ -720,7 +720,7 @@ let yojson_str_fields ~options ~path ({ ptype_loc = loc } as type_decl) =
         fields [%expr []]
       in
         [
-          Str.module_ (Mb.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "Yojson_fields") type_decl))
+          Str.module_ (Mb.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "Yojson_meta") type_decl))
                       (Mod.structure [
             Str.value Nonrecursive [Vb.mk [%expr [%e pvar "keys"]] [%expr [%e flist]]]
           ; Str.value Nonrecursive [Vb.mk [%expr [%e pvar "_"]] [%expr [%e evar "keys"]]]
@@ -729,14 +729,14 @@ let yojson_str_fields ~options ~path ({ ptype_loc = loc } as type_decl) =
     | _ -> []
 
 let yojson_sig_fields ~options ~path ({ ptype_loc = loc } as type_decl) =
-  let (_, want_fields) =  parse_options options in
-  match want_fields, type_decl.ptype_kind with
+  let (_, want_meta) =  parse_options options in
+  match want_meta, type_decl.ptype_kind with
   | false, _ | true, Ptype_open -> []
   | true, kind ->
     match kind, type_decl.ptype_manifest with
     | Ptype_record _, _ ->
       [
-        Sig.module_ (Md.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "Yojson_fields") type_decl))
+        Sig.module_ (Md.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "Yojson_meta") type_decl))
                     (Mty.signature [
           Sig.value (Val.mk (mknoloc "keys") [%type: string list]) ]))
       ]


### PR DESCRIPTION
The deriver option `fields` (`[@@deriving yojson { fields = true }]`) has been added. This generates a new module, `Yojson_fields`, containing the value `keys`, a string list of all the JSON keys.

A module was created for a couple of reasons: This allows other fields values/functions to be added later and it mirrors `[@@deriving fields]`.

Thus given
```ocaml
module Bar_to_only = struct
  type t = {
     fvalue : float
   ; svalue : string [@key "@svalue_json"]
   ; ivalue : int
  } [@@deriving to_yojson { strict = false } ]
end
```
The following module is generated:
```ocaml
module Yojson_fields = struct
  let keys = ["fvalue"; "@svalue_json"; "ivalue"] 
  let _ = keys 
end
```