### PR TITLE
Add section about runtime and jbuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Usage
 
 In order to use _deriving yojson_, require the package `ppx_deriving_yojson`.
 
+If you are using [jbuilder](https://github.com/ocaml/dune), add `ppx_deriving_yojson`
+to the `pps` section of `preprocess`. Ensure also that `yojson` and `ppx_deriving_yojson.runtime`
+are listed in the libraries.
+
 Syntax
 ------
 


### PR DESCRIPTION
Add section to README to avoid a common configuration mistake based on [this issue](https://discuss.ocaml.org/t/error-required-module-ppx-deriving-yojson-runtime-is-unavailable/1229).

A required step to build with `jbuilder` is adding `ppx_deriving_yojson.runtime`, or you'll see this:
![screen shot 2018-03-23 at 14 48 28](https://user-images.githubusercontent.com/7553006/37845458-5a5d789a-2ea9-11e8-826b-1f2bf739d08c.png)
