### PR TITLE
Switch to dune language 1.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.2)
+(lang dune 1.0)


### PR DESCRIPTION
When I tried to install ppx_deriving_yojson.3.3 I realized it fails because it specifies dune 1.2 language, but I had dune 1.0 installed. Since the dependency on dune 1.2 is not stated in the opam file, opam doesn't prompt me to install a newer dune.