### PR TITLE
use Yojson.Safe.t instead of Yojson.Safe.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ _deriving yojson_ generates three functions per type:
 ``` ocaml
 # #require "ppx_deriving_yojson";;
 # type ty = .. [@@deriving yojson];;
-val ty_of_yojson : Yojson.Safe.json -> (ty, string) Result.result
-val ty_of_yojson_exn : Yojson.Safe.json -> ty
-val ty_to_yojson : ty -> Yojson.Safe.json
+val ty_of_yojson : Yojson.Safe.t -> (ty, string) Result.result
+val ty_of_yojson_exn : Yojson.Safe.t -> ty
+val ty_to_yojson : ty -> Yojson.Safe.t
 ```
 
 When the deserializing function returns <code>\`Error loc</code>, `loc` points to the point in the JSON hierarchy where the error has occurred.
@@ -71,7 +71,7 @@ The following table summarizes the correspondence between OCaml types and JSON v
 | `ref`                  | 'a         |                                  |
 | `option`               | Null or 'a |                                  |
 | A record               | Object     |                                  |
-| `Yojson.Safe.json`     | any        | Identity transformation          |
+| `Yojson.Safe.t`        | any        | Identity transformation          |
 
 Variants (regular and polymorphic) are represented using arrays; the first element is a string with the name of the constructor, the rest are the arguments. Note that the implicit tuple in a polymorphic variant is flattened. For example:
 

--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "yojson"
+  "yojson" {>= "1.6.0" & < "2.0.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}
   "ppx_tools"    {build}

--- a/src/ppx_deriving_yojson.cppo.ml
+++ b/src/ppx_deriving_yojson.cppo.ml
@@ -84,6 +84,7 @@ let rec ser_expr_of_typ typ =
     [%expr fun x -> `List (Array.to_list (Array.map [%e ser_expr_of_typ typ] x))]
   | [%type: [%t? typ] option] ->
     [%expr function None -> `Null | Some x -> [%e ser_expr_of_typ typ] x]
+  | [%type: Yojson.Safe.json] -> [%expr fun x -> x]
   | [%type: Yojson.Safe.t] -> [%expr fun x -> x]
   | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
     let fwd = app (Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Suffix "to_yojson") lid)))
@@ -186,6 +187,7 @@ and desu_expr_of_typ ~path typ =
     decode [%pat? `List xs]
            [%expr map_bind [%e desu_expr_of_typ ~path typ] [] xs >|= Array.of_list]
   | [%type: Yojson.Safe.t] -> [%expr fun x -> Result.Ok x]
+  | [%type: Yojson.Safe.json] -> [%expr fun x -> Result.Ok x]
   | { ptyp_desc = Ptyp_tuple typs } ->
     decode [%pat? `List [%p plist (List.mapi (fun i _ -> pvar (argn i)) typs)]]
            (desu_fold ~path tuple typs)

--- a/src/ppx_deriving_yojson.cppo.ml
+++ b/src/ppx_deriving_yojson.cppo.ml
@@ -84,7 +84,7 @@ let rec ser_expr_of_typ typ =
     [%expr fun x -> `List (Array.to_list (Array.map [%e ser_expr_of_typ typ] x))]
   | [%type: [%t? typ] option] ->
     [%expr function None -> `Null | Some x -> [%e ser_expr_of_typ typ] x]
-  | [%type: Yojson.Safe.json] -> [%expr fun x -> x]
+  | [%type: Yojson.Safe.t] -> [%expr fun x -> x]
   | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
     let fwd = app (Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Suffix "to_yojson") lid)))
         (List.map ser_expr_of_typ args)
@@ -120,7 +120,7 @@ let rec ser_expr_of_typ typ =
                        deriver (Ppx_deriving.string_of_core_type typ))
     in
     Exp.function_ cases
-  | { ptyp_desc = Ptyp_var name } -> [%expr ([%e evar ("poly_"^name)] : _ -> Yojson.Safe.json)]
+  | { ptyp_desc = Ptyp_var name } -> [%expr ([%e evar ("poly_"^name)] : _ -> Yojson.Safe.t)]
   | { ptyp_desc = Ptyp_alias (typ, name) } ->
     [%expr fun x -> [%e evar ("poly_"^name)] x; [%e ser_expr_of_typ typ] x]
   | { ptyp_loc } ->
@@ -185,7 +185,7 @@ and desu_expr_of_typ ~path typ =
   | [%type: [%t? typ] array] ->
     decode [%pat? `List xs]
            [%expr map_bind [%e desu_expr_of_typ ~path typ] [] xs >|= Array.of_list]
-  | [%type: Yojson.Safe.json] -> [%expr fun x -> Result.Ok x]
+  | [%type: Yojson.Safe.t] -> [%expr fun x -> Result.Ok x]
   | { ptyp_desc = Ptyp_tuple typs } ->
     decode [%pat? `List [%p plist (List.mapi (fun i _ -> pvar (argn i)) typs)]]
            (desu_fold ~path tuple typs)
@@ -220,7 +220,7 @@ and desu_expr_of_typ ~path typ =
         | Result.Error _ -> [%e expr]]) error
       |> Exp.case [%pat? _]
     in
-    [%expr fun (json : Yojson.Safe.json) ->
+    [%expr fun (json : Yojson.Safe.t) ->
       [%e Exp.match_ [%expr json] (tag_cases @ [inherits_case])]]
   | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
      let fwd = app (Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Suffix "of_yojson") lid)))
@@ -228,7 +228,7 @@ and desu_expr_of_typ ~path typ =
      (* eta-expansion is necessary for recursive groups *)
      [%expr fun x -> [%e fwd] x]
   | { ptyp_desc = Ptyp_var name } ->
-    [%expr ([%e evar ("poly_"^name)] : Yojson.Safe.json -> _ error_or)]
+    [%expr ([%e evar ("poly_"^name)] : Yojson.Safe.t -> _ error_or)]
   | { ptyp_desc = Ptyp_alias (typ, name) } ->
     [%expr fun x -> [%e evar ("poly_"^name)] x; [%e desu_expr_of_typ ~path typ] x]
   | { ptyp_loc } ->
@@ -242,8 +242,8 @@ let ser_type_of_decl ~options ~path:_ type_decl =
   ignore (parse_options options);
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   let polymorphize = Ppx_deriving.poly_arrow_of_type_decl
-                       (fun var -> [%type: [%t var] -> Yojson.Safe.json]) type_decl in
-  polymorphize [%type: [%t typ] -> Yojson.Safe.json]
+                       (fun var -> [%type: [%t var] -> Yojson.Safe.t]) type_decl in
+  polymorphize [%type: [%t typ] -> Yojson.Safe.t]
 
 let ser_str_of_record varname labels =
   let fields =
@@ -282,7 +282,7 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let orig_mod = Mod.ident (mknoloc lid) in
       ([Str.module_ (Mb.mk (mknoloc mod_name) orig_mod)],
        [Vb.mk (pvar to_yojson_name)
-              (polymorphize [%expr ([%e ser] : [%t typ] -> Yojson.Safe.json)])],
+              (polymorphize [%expr ([%e ser] : [%t typ] -> Yojson.Safe.t)])],
        [])
     | Some _ ->
       raise_errorf ~loc "%s: extensible type manifest should be a type name" deriver
@@ -291,9 +291,9 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
           (Ppx_deriving.fold_left_type_decl (fun acc name -> name :: acc) [] type_decl)
       in
       let polymorphize_ser  = Ppx_deriving.poly_arrow_of_type_decl
-        (fun var -> [%type: [%t var] -> Yojson.Safe.json]) type_decl
+        (fun var -> [%type: [%t var] -> Yojson.Safe.t]) type_decl
       in
-      let ty = Typ.poly poly_vars (polymorphize_ser [%type: [%t typ] -> Yojson.Safe.json]) in
+      let ty = Typ.poly poly_vars (polymorphize_ser [%type: [%t typ] -> Yojson.Safe.t]) in
       let default_fun =
         let type_path = String.concat "." (path @ [type_decl.ptype_name.txt]) in
         let e_type_path = Exp.constant (Pconst_string (type_path, None)) in
@@ -424,12 +424,12 @@ let error_or typ = [%type: [%t typ] Ppx_deriving_yojson_runtime.error_or]
 let desu_type_of_decl_poly ~options ~path:_ type_decl type_ =
   ignore (parse_options options);
   let polymorphize = Ppx_deriving.poly_arrow_of_type_decl
-                       (fun var -> [%type: Yojson.Safe.json -> [%t error_or var]]) type_decl in
+                       (fun var -> [%type: Yojson.Safe.t -> [%t error_or var]]) type_decl in
   polymorphize type_
 
 let desu_type_of_decl ~options ~path type_decl =
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
-  desu_type_of_decl_poly ~options ~path type_decl [%type: Yojson.Safe.json -> [%t error_or typ]]
+  desu_type_of_decl_poly ~options ~path type_decl [%type: Yojson.Safe.t -> [%t error_or typ]]
 
 
 let desu_str_of_record ~is_strict ~error ~path wrap_record labels =
@@ -489,7 +489,7 @@ let desu_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let desu = desu_expr_of_typ ~path manifest in
       let lid = Ppx_deriving.mangle_lid (`PrefixSuffix ("M", "of_yojson")) lid in
       let orig_mod = Mod.ident (mknoloc lid) in
-      let poly_desu = polymorphize [%expr ([%e wrap_runtime desu] : Yojson.Safe.json -> _)] in
+      let poly_desu = polymorphize [%expr ([%e wrap_runtime desu] : Yojson.Safe.t -> _)] in
       ([Str.module_ (Mb.mk (mknoloc mod_name) orig_mod)],
        [Vb.mk (pvar of_yojson_name) poly_desu],
        [])
@@ -500,9 +500,9 @@ let desu_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
         (Ppx_deriving.fold_left_type_decl (fun acc name -> name :: acc) [] type_decl)
       in
       let polymorphize_desu = Ppx_deriving.poly_arrow_of_type_decl
-        (fun var -> [%type: Yojson.Safe.json -> [%t error_or var]]) type_decl in
+        (fun var -> [%type: Yojson.Safe.t -> [%t error_or var]]) type_decl in
       let ty = Typ.poly poly_vars
-        (polymorphize_desu [%type: Yojson.Safe.json -> [%t error_or typ]])
+        (polymorphize_desu [%type: Yojson.Safe.t -> [%t error_or typ]])
       in
       let default_fun = Exp.function_ [Exp.case [%pat? _] top_error] in
       let poly_fun = polymorphize default_fun in
@@ -644,9 +644,9 @@ let ser_sig_of_type ~options ~path type_decl =
     in
     let typ = Ppx_deriving.core_type_of_type_decl type_decl in
     let polymorphize_ser  = Ppx_deriving.poly_arrow_of_type_decl
-      (fun var -> [%type: [%t var] -> Yojson.Safe.json]) type_decl
+      (fun var -> [%type: [%t var] -> Yojson.Safe.t]) type_decl
     in
-    let ty = Typ.poly poly_vars (polymorphize_ser [%type: [%t typ] -> Yojson.Safe.json]) in
+    let ty = Typ.poly poly_vars (polymorphize_ser [%type: [%t typ] -> Yojson.Safe.t]) in
     let typ = Type.mk ~kind:(Ptype_record
        [Type.field ~mut:Mutable (mknoloc "f") ty]) (mknoloc "t_to_yojson")
     in
@@ -673,7 +673,7 @@ let desu_sig_of_type ~options ~path type_decl =
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   let of_yojson_exn =
     Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Suffix "of_yojson_exn") type_decl))
-                      (desu_type_of_decl_poly ~options ~path type_decl [%type: Yojson.Safe.json -> [%t typ]]))
+                      (desu_type_of_decl_poly ~options ~path type_decl [%type: Yojson.Safe.t -> [%t typ]]))
   in
   match type_decl.ptype_kind with
   | Ptype_open ->
@@ -685,9 +685,9 @@ let desu_sig_of_type ~options ~path type_decl =
     in
     let typ = Ppx_deriving.core_type_of_type_decl type_decl in
     let polymorphize_desu = Ppx_deriving.poly_arrow_of_type_decl
-      (fun var -> [%type: Yojson.Safe.json -> [%t error_or var]]) type_decl in
+      (fun var -> [%type: Yojson.Safe.t -> [%t error_or var]]) type_decl in
     let ty = Typ.poly poly_vars
-      (polymorphize_desu [%type: Yojson.Safe.json -> [%t error_or typ]])
+      (polymorphize_desu [%type: Yojson.Safe.t -> [%t error_or typ]])
     in
     let typ = Type.mk ~kind:(Ptype_record
        [Type.field ~mut:Mutable (mknoloc "f") ty]) (mknoloc "t_of_yojson")

--- a/src/ppx_deriving_yojson.cppo.ml
+++ b/src/ppx_deriving_yojson.cppo.ml
@@ -84,7 +84,7 @@ let rec ser_expr_of_typ typ =
     [%expr fun x -> `List (Array.to_list (Array.map [%e ser_expr_of_typ typ] x))]
   | [%type: [%t? typ] option] ->
     [%expr function None -> `Null | Some x -> [%e ser_expr_of_typ typ] x]
-  | [%type: Yojson.Safe.json] -> [%expr fun x -> x]
+  | [%type: Yojson.Safe.json]
   | [%type: Yojson.Safe.t] -> [%expr fun x -> x]
   | { ptyp_desc = Ptyp_constr ({ txt = lid }, args) } ->
     let fwd = app (Exp.ident (mknoloc (Ppx_deriving.mangle_lid (`Suffix "to_yojson") lid)))
@@ -186,7 +186,7 @@ and desu_expr_of_typ ~path typ =
   | [%type: [%t? typ] array] ->
     decode [%pat? `List xs]
            [%expr map_bind [%e desu_expr_of_typ ~path typ] [] xs >|= Array.of_list]
-  | [%type: Yojson.Safe.t] -> [%expr fun x -> Result.Ok x]
+  | [%type: Yojson.Safe.t]
   | [%type: Yojson.Safe.json] -> [%expr fun x -> Result.Ok x]
   | { ptyp_desc = Ptyp_tuple typs } ->
     decode [%pat? `List [%p plist (List.mapi (fun i _ -> pvar (argn i)) typs)]]

--- a/src_test/test_ppx_yojson.cppo.ml
+++ b/src_test/test_ppx_yojson.cppo.ml
@@ -217,7 +217,7 @@ let test_field_err _ctxt =
                (Result.Error "Test_ppx_yojson.geo.lat")
                (geo_of_yojson (`Assoc ["Longitude", (`Float 42.0)]))
 
-type id = Yojson.Safe.json [@@deriving yojson]
+type id = Yojson.Safe.t [@@deriving yojson]
 let test_id _ctxt =
   assert_roundtrip pp_json id_to_yojson id_of_yojson
                    (`Int 42) "42"


### PR DESCRIPTION
After Yojson 1.6.0 release Yojson.Safe.t should be used instead of Yojson.Safe.json and it emits warning...and dune forces warnings as errors by default, so if you just do `opam upgrade` - you will not be able to build your project.
I really don't understand how ppx works, I've just replaces all occurrences of Yoson.Safe.json and it seems to be working for me. :)