### PR TITLE
Restrict to Yojson < 1.6 to prevent warnings 3

### DIFF
--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -20,7 +20,7 @@ depends: [
   "ppxfind"      {build}
   "dune"         {build & >= "1.0"}
   "cppo"         {build}
-  "ounit"        {with-test}
+  "ounit"        {with-test & >= "2.0.0"}
 ]
 synopsis:
   "JSON codec generator for OCaml"

--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -13,7 +13,7 @@ build: [
 ]
 depends: [
   "ocaml" {>= "4.04.0"}
-  "yojson"
+  "yojson" {< "1.6.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}
   "ppx_tools"    {build}


### PR DESCRIPTION
I kind of screwed up by deprecating the `json` alias in the same Yojson release as introducing the type `t`. If you don't use `ppx_deriving_yojson` it's all right but if you do, especially if you use dune, all your dev builds are going to fail and there's not much you can do about it. I didn't realize that.

To make it up to everyone using `ppx_deriving_yojson` I suggest the following course of action:
1. I add this restriction to all existing `ppx_deriving_yojson` versions on `opam-repository`
2. I then submit a PR to `ppx_deriving_yojson` that uses the type `t` instead of `json` and depends on `yojson {>= 1.6.0 & < 2.0.0}`
3. We release a new `ppx_deriving_version`, please?
4. I try not to screw up anymore

Let me know what you think!