### PR TITLE
Add lower bound on ounit dependency

### DIFF
--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -20,7 +20,7 @@ depends: [
   "ppxfind"      {build}
   "dune"         {build & >= "1.0"}
   "cppo"         {build}
-  "ounit"        {with-test}
+  "ounit"        {with-test & >= "2.0.0"}
 ]
 synopsis:
   "JSON codec generator for OCaml"


### PR DESCRIPTION
As promised, also fixed it for older versions in https://github.com/ocaml/opam-repository/pull/13356