### PR TITLE
Remove 4.03-related ifdefs

### DIFF
--- a/src_test/test_ppx_yojson.cppo.ml
+++ b/src_test/test_ppx_yojson.cppo.ml
@@ -65,10 +65,8 @@ type v  = A | B of int | C of int * string
 [@@deriving show, yojson]
 type r  = { x : int; y : string }
 [@@deriving show, yojson]
-#if OCAML_VERSION >= (4, 03, 0)
 type rv = RA | RB of int | RC of int * string | RD of { z : string }
 [@@deriving show, yojson]
-#endif
 
 let test_unit _ctxt =
   assert_roundtrip pp_u u_to_yojson u_of_yojson
@@ -190,7 +188,6 @@ let test_rec _ctxt =
   assert_roundtrip pp_r r_to_yojson r_of_yojson
                    {x=42; y="foo"} "{\"x\":42,\"y\":\"foo\"}"
 
-#if OCAML_VERSION >= (4, 03, 0)
 let test_recvar _ctxt =
   assert_roundtrip pp_rv rv_to_yojson rv_of_yojson
                    RA "[\"RA\"]";
@@ -200,7 +197,6 @@ let test_recvar _ctxt =
                    (RC(42, "foo")) "[\"RC\", 42, \"foo\"]";
   assert_roundtrip pp_rv rv_to_yojson rv_of_yojson
                    (RD{z="foo"}) "[\"RD\", {\"z\": \"foo\"}]"
-#endif
 
 type geo = {
   lat : float [@key "Latitude"]  ;
@@ -440,9 +436,7 @@ let suite = "Test ppx_yojson" >::: [
     "test_pvar"      >:: test_pvar;
     "test_var"       >:: test_var;
     "test_rec"       >:: test_rec;
-#if OCAML_VERSION >= (4, 03, 0)
     "test_recvar"    >:: test_recvar;
-#endif
     "test_key"       >:: test_key;
     "test_id"        >:: test_id;
     "test_custvar"   >:: test_custvar;


### PR DESCRIPTION
According to the opam file, 4.03 is not supported anymore, so this always holds.