### PR TITLE
define safe_map with rev and rev_map for serializing long lists

### DIFF
--- a/src/ppx_deriving_yojson.cppo.ml
+++ b/src/ppx_deriving_yojson.cppo.ml
@@ -71,7 +71,7 @@ let rec ser_expr_of_typ typ =
   | [%type: bytes]           -> [%expr fun x -> `String (Bytes.to_string x)]
   | [%type: char]            -> [%expr fun x -> `String (String.make 1 x)]
   | [%type: [%t? typ] ref]   -> [%expr fun x -> [%e ser_expr_of_typ typ] !x]
-  | [%type: [%t? typ] list]  -> [%expr fun x -> `List (List.map [%e ser_expr_of_typ typ] x)]
+  | [%type: [%t? typ] list]  -> [%expr fun x -> `List (safe_map [%e ser_expr_of_typ typ] x)]
   | [%type: int32] | [%type: Int32.t] ->
     [%expr fun x -> `Intlit (Int32.to_string x)]
   | [%type: int64] | [%type: Int64.t] ->

--- a/src/ppx_deriving_yojson_runtime.ml
+++ b/src/ppx_deriving_yojson_runtime.ml
@@ -13,4 +13,7 @@ let rec map_bind f acc xs =
 
 type 'a error_or = ('a, string) Result.result
 
+(** [safe_map f l] returns the same value as [List.map f l], but
+    computes it tail-recursively so that large list lengths don't
+    cause a stack overflow *)
 let safe_map f l = List.rev (List.rev_map f l)

--- a/src/ppx_deriving_yojson_runtime.ml
+++ b/src/ppx_deriving_yojson_runtime.ml
@@ -12,3 +12,5 @@ let rec map_bind f acc xs =
   | [] -> Result.Ok (List.rev acc)
 
 type 'a error_or = ('a, string) Result.result
+
+let safe_map f l = List.rev (List.rev_map f l)

--- a/src/ppx_deriving_yojson_runtime.mli
+++ b/src/ppx_deriving_yojson_runtime.mli
@@ -4,6 +4,8 @@ val ( >>= ) : 'a error_or -> ('a -> 'b error_or) -> 'b error_or
 val ( >|= ) : 'a error_or -> ('a -> 'b) -> 'b error_or
 val map_bind : ('a -> 'b error_or) -> 'b list -> 'a list -> 'b list error_or
 
+val safe_map : ('a -> 'b) -> 'a list -> 'b list
+
 module List : (module type of List)
 module String : (module type of String)
 module Bytes : (module type of Bytes)

--- a/src/ppx_deriving_yojson_runtime.mli
+++ b/src/ppx_deriving_yojson_runtime.mli
@@ -4,6 +4,9 @@ val ( >>= ) : 'a error_or -> ('a -> 'b error_or) -> 'b error_or
 val ( >|= ) : 'a error_or -> ('a -> 'b) -> 'b error_or
 val map_bind : ('a -> 'b error_or) -> 'b list -> 'a list -> 'b list error_or
 
+(** [safe_map f l] returns the same value as [List.map f l], but
+    computes it tail-recursively so that large list lengths don't
+    cause a stack overflow *)
 val safe_map : ('a -> 'b) -> 'a list -> 'b list
 
 module List : (module type of List)

--- a/src_test/test_ppx_yojson.cppo.ml
+++ b/src_test/test_ppx_yojson.cppo.ml
@@ -143,7 +143,15 @@ let test_list _ctxt =
   assert_roundtrip pp_xl xl_to_yojson xl_of_yojson
                    [] "[]";
   assert_roundtrip pp_xl xl_to_yojson xl_of_yojson
-                   [42; 43] "[42, 43]"
+                   [42; 43] "[42, 43]";
+  let lst = List.init 500000 (fun i -> i mod 100) in
+  let buf = Buffer.create (5000 * 390 + 4) in
+  Buffer.add_string buf "[";
+  Buffer.add_string buf (string_of_int (List.hd lst));
+  List.iter (fun x -> Buffer.add_string buf ", "; Buffer.add_string buf (string_of_int x)) (List.tl lst);
+  Buffer.add_string buf "]";
+  let str = Bytes.to_string (Buffer.to_bytes buf) in
+  assert_roundtrip pp_xl xl_to_yojson xl_of_yojson lst str
 
 let test_array _ctxt =
   assert_roundtrip pp_xa xa_to_yojson xa_of_yojson

--- a/src_test/test_ppx_yojson.cppo.ml
+++ b/src_test/test_ppx_yojson.cppo.ml
@@ -144,8 +144,12 @@ let test_list _ctxt =
                    [] "[]";
   assert_roundtrip pp_xl xl_to_yojson xl_of_yojson
                    [42; 43] "[42, 43]";
-  let lst = List.init 500000 (fun i -> i mod 100) in
-  let buf = Buffer.create (5000 * 390 + 4) in
+  let rec make_list i acc =
+            if i = 0
+            then (i mod 100 :: acc)
+            else make_list (i - 1) (i mod 100 :: acc) in
+  let lst =  make_list (500_000 - 1) [] in
+  let buf = Buffer.create (5_000 * 390 + 4) in
   Buffer.add_string buf "[";
   Buffer.add_string buf (string_of_int (List.hd lst));
   List.iter (fun x -> Buffer.add_string buf ", "; Buffer.add_string buf (string_of_int x)) (List.tl lst);


### PR DESCRIPTION
Fixes #96 by using a `safe_map` function defined in terms of `rev` and `rev_map`, which avoids a potential stack overflow when serializing long lists.

Problem: the test I'm adding for this may not be good enough, since I can't get it to fail with the previous implementation using `List.map`