### PR TITLE
OCaml 4.08 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   global:
   - PINS="ppx_deriving_yojson:."
   matrix:
+  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.08"
   - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.07"
   - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.06"
   - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.05"


### PR DESCRIPTION
This diff adds support for OCaml 4.08 in ppx_deriving_yojson, following the recent additions in ppx_deriving (https://github.com/ocaml-ppx/ppx_deriving/pull/193).

Tests may be failing on 4.08 due to a pending release for the aforementioned changes.

I tested this with a local pin of ppx_deriving master.

fixes #98 