### PR TITLE
safe_map fix

### DIFF
--- a/src/ppx_deriving_yojson.cppo.ml
+++ b/src/ppx_deriving_yojson.cppo.ml
@@ -865,7 +865,7 @@ let () =
    ));
   Ppx_deriving.(register
    (create "to_yojson"
-    ~core_type:ser_expr_of_typ
+    ~core_type:(fun typ -> wrap_runtime (ser_expr_of_typ typ))
     ~type_decl_str:(structure (on_str_decls str_of_type_to_yojson))
     ~type_ext_str:ser_str_of_type_ext
     ~type_decl_sig:(on_sig_decls sig_of_type_to_yojson)

--- a/src/ppx_deriving_yojson.cppo.ml
+++ b/src/ppx_deriving_yojson.cppo.ml
@@ -70,6 +70,15 @@ let parse_options options =
     want_exn = !exn;
   }
 
+let poly_fun names expr =
+  List.fold_right (fun name expr ->
+      #if OCAML_VERSION >= (4, 05, 0)
+      let name = name.Location.txt in
+      #endif
+      [%expr fun [%p pvar ("poly_"^name)] -> [%e expr]]
+    ) names expr
+
+
 let rec ser_expr_of_typ typ =
   let attr_int_encoding typ =
     match attr_int_encoding typ with `String -> "String" | `Int -> "Intlit"
@@ -149,6 +158,8 @@ let rec ser_expr_of_typ typ =
   | { ptyp_desc = Ptyp_var name } -> [%expr ([%e evar ("poly_"^name)] : _ -> Yojson.Safe.t)]
   | { ptyp_desc = Ptyp_alias (typ, name) } ->
     [%expr fun x -> [%e evar ("poly_"^name)] x; [%e ser_expr_of_typ typ] x]
+  | { ptyp_desc = Ptyp_poly (names, typ) } ->
+     poly_fun names (ser_expr_of_typ typ)
   | { ptyp_loc } ->
     raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                  deriver (Ppx_deriving.string_of_core_type typ)
@@ -286,6 +297,8 @@ and desu_expr_of_typ ~path typ =
     [%expr ([%e evar ("poly_"^name)] : Yojson.Safe.t -> _ error_or)]
   | { ptyp_desc = Ptyp_alias (typ, name) } ->
     [%expr fun x -> [%e evar ("poly_"^name)] x; [%e desu_expr_of_typ ~path typ] x]
+  | { ptyp_desc = Ptyp_poly (names, typ) } ->
+     poly_fun names (desu_expr_of_typ ~path typ)
   | { ptyp_loc } ->
     raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                  deriver (Ppx_deriving.string_of_core_type typ)
@@ -865,7 +878,9 @@ let () =
    ));
   Ppx_deriving.(register
    (create "to_yojson"
-    ~core_type:(fun typ -> wrap_runtime (ser_expr_of_typ typ))
+    ~core_type:(fun typ ->
+      let typ = Ppx_deriving.strong_type_of_type typ in
+      wrap_runtime (ser_expr_of_typ typ))
     ~type_decl_str:(structure (on_str_decls str_of_type_to_yojson))
     ~type_ext_str:ser_str_of_type_ext
     ~type_decl_sig:(on_sig_decls sig_of_type_to_yojson)
@@ -874,7 +889,9 @@ let () =
   ));
   Ppx_deriving.(register
    (create "of_yojson"
-    ~core_type:(fun typ -> wrap_runtime (desu_expr_of_typ ~path:[] typ))
+    ~core_type:(fun typ ->
+      let typ = Ppx_deriving.strong_type_of_type typ in
+      wrap_runtime (desu_expr_of_typ ~path:[] typ))
     ~type_decl_str:(structure (on_str_decls str_of_type_of_yojson))
     ~type_ext_str:desu_str_of_type_ext
     ~type_decl_sig:(on_sig_decls sig_of_type_of_yojson)

--- a/src_test/test_ppx_yojson.cppo.ml
+++ b/src_test/test_ppx_yojson.cppo.ml
@@ -139,6 +139,12 @@ let test_option _ctxt =
   assert_roundtrip pp_xo xo_to_yojson xo_of_yojson
                    None "null"
 
+let test_poly _ctxt =
+  assert_roundtrip pp_xo
+    (([%to_yojson: 'a option] [%to_yojson: int]))
+    (([%of_yojson: 'a option] [%of_yojson: int]))
+                   (Some 42) "42"
+
 let test_list _ctxt =
   assert_roundtrip pp_xl xl_to_yojson xl_of_yojson
                    [] "[]";
@@ -407,14 +413,14 @@ module Test_extension_forms = struct
   let _ = [%to_yojson: int array], [%of_yojson: int array]
   let _ = [%to_yojson: int * int], [%of_yojson: int * int]
 
-  (* let _ =  [%to_yojson: 'a option],
-   *         [%of_yojson: 'a option]
-   * let _ = [%to_yojson: [ `A | `B of int | `C of int * string ]],
-   *         [%of_yojson: [ `A | `B of int | `C of int * string ]]
-   * let _ = [%to_yojson: [ `C of 'a ]],
-   *         [%of_yojson: [ `C of 'a ]]
-   * let _ = [%to_yojson: [ pva | pvb | int pvc ]],
-   *         [%of_yojson: [ pva | pvb | int pvc ]] *)
+  let _ =  [%to_yojson: 'a option],
+          [%of_yojson: 'a option]
+  let _ = [%to_yojson: [ `A | `B of int | `C of int * string ]],
+          [%of_yojson: [ `A | `B of int | `C of int * string ]]
+  let _ = [%to_yojson: [ `C of 'a ]],
+          [%of_yojson: [ `C of 'a ]]
+  let _ = [%to_yojson: [ pva | pvb | int pvc ]],
+          [%of_yojson: [ pva | pvb | int pvc ]]
 end
 
 (* this test checks that we can derive an _exn deserializer
@@ -478,6 +484,7 @@ let suite = "Test ppx_yojson" >::: [
     "test_string"    >:: test_string;
     "test_ref"       >:: test_ref;
     "test_option"    >:: test_option;
+    "test_poly"      >:: test_poly;
     "test_list"      >:: test_list;
     "test_array"     >:: test_array;
     "test_tuple"     >:: test_tuple;

--- a/src_test/test_ppx_yojson.cppo.ml
+++ b/src_test/test_ppx_yojson.cppo.ml
@@ -384,6 +384,39 @@ module TestShadowing = struct
 
 end
 
+module Test_extension_forms = struct
+  let _ = [%to_yojson: unit], [%of_yojson: unit]
+  let _ = [%to_yojson: int], [%of_yojson: int]
+  let _ = [%to_yojson: int32], [%of_yojson: int32]
+  let _ = [%to_yojson: Int32.t], [%of_yojson: Int32.t]
+  let _ = [%to_yojson: int64], [%of_yojson: int64]
+  let _ = [%to_yojson: Int64.t], [%of_yojson: Int64.t]
+  let _ = [%to_yojson: nativeint], [%of_yojson: nativeint]
+  let _ = [%to_yojson: Nativeint.t], [%of_yojson: Nativeint.t]
+  let _ = [%to_yojson: int64], [%of_yojson: int64]
+  let _ = [%to_yojson: nativeint], [%of_yojson: nativeint]
+  let _ = [%to_yojson: float], [%of_yojson: float]
+  let _ = [%to_yojson: bool], [%of_yojson: bool]
+  let _ = [%to_yojson: char], [%of_yojson: char]
+  let _ = [%to_yojson: string], [%of_yojson: string]
+  let _ = [%to_yojson: bytes], [%of_yojson: bytes]
+  let _ = [%to_yojson: int], [%of_yojson: int]
+  let _ = [%to_yojson: int ref], [%of_yojson: int ref]
+  let _ = [%to_yojson: int option], [%of_yojson: int option]
+  let _ = [%to_yojson: int list], [%of_yojson: int list]
+  let _ = [%to_yojson: int array], [%of_yojson: int array]
+  let _ = [%to_yojson: int * int], [%of_yojson: int * int]
+
+  (* let _ =  [%to_yojson: 'a option],
+   *         [%of_yojson: 'a option]
+   * let _ = [%to_yojson: [ `A | `B of int | `C of int * string ]],
+   *         [%of_yojson: [ `A | `B of int | `C of int * string ]]
+   * let _ = [%to_yojson: [ `C of 'a ]],
+   *         [%of_yojson: [ `C of 'a ]]
+   * let _ = [%to_yojson: [ pva | pvb | int pvc ]],
+   *         [%of_yojson: [ pva | pvb | int pvc ]] *)
+end
+
 (* this test checks that we can derive an _exn deserializer
    even if we use sub-types that are derived with {exn = false} *)
 module Test_exn_depends_on_non_exn = struct


### PR DESCRIPTION
When trying to add a regression test for #100, I found another issue that is not directly related: the following code

```ocaml
let _ = [%to_yojson: 'a option]
```

fails with "Unbound identifier `poly_a`". The present PR fixes both the `safe_map` issue (that woud only occur when using `[%{to,of}_yojson]`, not the more common `[@@deriving yojson]` form) and this issue; the code generated for `[%to_yojson: 'a option]` is of the form `fun poly_a -> <previous code>`, so in particular it is correct to write an application `[%to_yojson 'a option] [%to_yojson int]`, and this should be equivalent to `[%to_yojson int option]`.