### PR TITLE
Remove build flags from dune & ppx

### DIFF
--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -16,9 +16,9 @@ depends: [
   "yojson" {>= "1.6.0" & < "2.0.0"}
   "result"
   "ppx_deriving" {>= "4.0" & < "5.0"}
-  "ppx_tools"    {build}
-  "ppxfind"      {build}
-  "dune"         {build & >= "1.0"}
+  "ppx_tools"
+  "ppxfind"
+  "dune"
   "cppo"         {build}
   "ounit"        {with-test & >= "2.0.0"}
 ]


### PR DESCRIPTION
These are not valid build dependencies. If any of these change them,
ppx_deriving_yojson should also be rebuilt.
