### PR TITLE
Add support for OCaml 4.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
   global:
   - PINS="ppx_deriving_yojson:."
   matrix:
+  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.10.0+rc2" OCAML_BETA="enable"
+  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.09"
   - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.08"
   - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.07"
   - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.06"

--- a/src/ppx_deriving_yojson.cppo.ml
+++ b/src/ppx_deriving_yojson.cppo.ml
@@ -22,6 +22,13 @@ open Parsetree
 open Ast_helper
 open Ast_convenience
 
+
+#if OCAML_VERSION >= (4, 10, 0)
+let mod_mknoloc x = mknoloc (Some x)
+#else
+let mod_mknoloc x = mknoloc x
+#endif
+
 let deriver = "yojson"
 let raise_errorf = Ppx_deriving.raise_errorf
 
@@ -362,7 +369,7 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let ser = ser_expr_of_typ manifest in
       let lid = Ppx_deriving.mangle_lid (`PrefixSuffix ("M", "to_yojson")) lid in
       let orig_mod = Mod.ident (mknoloc lid) in
-      ([Str.module_ (Mb.mk (mknoloc mod_name) orig_mod)],
+      ([Str.module_ (Mb.mk (mod_mknoloc mod_name) orig_mod)],
        [Vb.mk (pvar to_yojson_name)
               (polymorphize [%expr ([%e ser] : [%t typ] -> Yojson.Safe.t)])],
        [])
@@ -395,7 +402,7 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let flid = lid (Printf.sprintf "%s.f" mod_name) in
       let field = Exp.field (Exp.ident flid) (flid) in
       let mod_ =
-        Str.module_ (Mb.mk (mknoloc mod_name)
+        Str.module_ (Mb.mk (mod_mknoloc mod_name)
                     (Mod.structure [
           Str.type_ Nonrecursive [typ];
           Str.value Nonrecursive [record];
@@ -575,7 +582,7 @@ let desu_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let lid = Ppx_deriving.mangle_lid (`PrefixSuffix ("M", "of_yojson")) lid in
       let orig_mod = Mod.ident (mknoloc lid) in
       let poly_desu = polymorphize [%expr ([%e wrap_runtime desu] : Yojson.Safe.t -> _)] in
-      ([Str.module_ (Mb.mk (mknoloc mod_name) orig_mod)],
+      ([Str.module_ (Mb.mk (mod_mknoloc mod_name) orig_mod)],
        [Vb.mk (pvar of_yojson_name) poly_desu],
        [])
     | Some _ ->
@@ -601,7 +608,7 @@ let desu_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let flid = lid (Printf.sprintf "%s.f" mod_name) in
       let field = Exp.field (Exp.ident flid) flid in
       let mod_ =
-        Str.module_ (Mb.mk (mknoloc mod_name)
+        Str.module_ (Mb.mk (mod_mknoloc mod_name)
                     (Mod.structure [
           Str.type_ Nonrecursive [typ];
           Str.value Nonrecursive [record];
@@ -737,7 +744,7 @@ let ser_sig_of_type ~options ~path type_decl =
     in
     let record = Val.mk (mknoloc "f") (Typ.constr (lid "t_to_yojson") []) in
     let mod_ =
-      Sig.module_ (Md.mk (mknoloc mod_name)
+      Sig.module_ (Md.mk (mod_mknoloc mod_name)
                   (Mty.signature [
         Sig.type_ Nonrecursive [typ];
         Sig.value record;
@@ -779,7 +786,7 @@ let desu_sig_of_type ~options ~path type_decl =
     in
     let record = Val.mk (mknoloc "f") (Typ.constr (lid "t_of_yojson") []) in
     let mod_ =
-      Sig.module_ (Md.mk (mknoloc mod_name)
+      Sig.module_ (Md.mk (mod_mknoloc mod_name)
                   (Mty.signature [
         Sig.type_ Nonrecursive [typ];
         Sig.value record;
@@ -807,7 +814,7 @@ let yojson_str_fields ~options ~path:_ type_decl =
         fields [%expr []]
       in
         [
-          Str.module_ (Mb.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "Yojson_meta") type_decl))
+          Str.module_ (Mb.mk (mod_mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "Yojson_meta") type_decl))
                       (Mod.structure [
             Str.value Nonrecursive [Vb.mk [%expr [%e pvar "keys"]] [%expr [%e flist]]]
           ; Str.value Nonrecursive [Vb.mk [%expr [%e pvar "_"]] [%expr [%e evar "keys"]]]
@@ -823,7 +830,7 @@ let yojson_sig_fields ~options ~path:_ type_decl =
     match kind, type_decl.ptype_manifest with
     | Ptype_record _, _ ->
       [
-        Sig.module_ (Md.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "Yojson_meta") type_decl))
+        Sig.module_ (Md.mk (mod_mknoloc (Ppx_deriving.mangle_type_decl (`Prefix "Yojson_meta") type_decl))
                     (Mty.signature [
           Sig.value (Val.mk (mknoloc "keys") [%type: string list]) ]))
       ]


### PR DESCRIPTION
This adds support for OCaml 4.10.

Relies on https://github.com/ocaml-ppx/ppx_deriving/pull/211 and https://github.com/ocaml-ppx/ppx_tools/pull/79