### PR TITLE
Tentative lightning OCaml 4.11.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ env:
   global:
   - PINS="ppx_deriving_yojson:."
   matrix:
-  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.10.0+rc2" OCAML_BETA="enable"
+  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.11.0+trunk" OCAML_BETA="enable"
+  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.10"
   - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.09"
   - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.08"
   - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.07"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ env:
   global:
   - PINS="ppx_deriving_yojson:."
   matrix:
-  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.11.0+trunk" OCAML_BETA="enable"
+  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.11.0+trunk"
+    OCAML_BETA="enable"
+    PINS="ppx_deriving_yojson:.
+      ppx_deriving:https://github.com/ocaml-ppx/ppx_deriving.git#pre-ppxlib
+      ppx_tools:https://github.com/kit-ty-kate/ppx_tools.git#411"
   - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.10"
   - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.09"
   - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.08"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sponsored by [Evil Martians](http://evilmartians.com).
 
 [pd]: https://github.com/ocaml-ppx/ppx_deriving
 [json]: http://tools.ietf.org/html/rfc4627
-[yojson]: http://mjambon.com/yojson.html
+[yojson]: https://github.com/ocaml-community/yojson
 
 Installation
 ------------
@@ -44,13 +44,13 @@ val ty_of_yojson : Yojson.Safe.t -> (ty, string) Result.result
 val ty_to_yojson : ty -> Yojson.Safe.t
 ```
 
-When the deserializing function returns <code>\`Error loc</code>, `loc` points to the point in the JSON hierarchy where the error has occurred.
+When the deserializing function returns <code>Error loc</code>, `loc` points to the point in the JSON hierarchy where the error has occurred.
 
 It is possible to generate only serializing or deserializing functions by using `[@@deriving to_yojson]` or `[@@deriving of_yojson]`. It is also possible to generate an expression for serializing or deserializing a type by using `[%to_yojson:]` or `[%of_yojson:]`; non-conflicting versions `[%derive.to_yojson:]` or `[%derive.of_yojson:]` are available as well. Custom or overriding serializing or deserializing functions can be provided on a per-field basis via `[@to_yojson]` and `[@of_yojson]` attributes.
 
 If the type is called `t`, the functions generated are `{of,to}_yojson` instead of `t_{of,to}_yojson`.
 
-Using the option `[@@deriving yojson { exn = true }]` will also generate a function `ty_of_yojson_exn : Yojson.Safe.t -> ty` which raises `Failure err` on error instead of returning an `'a or_error`.
+Using the option `[@@deriving yojson { exn = true }]` will also generate a function `ty_of_yojson_exn : Yojson.Safe.t -> ty` which raises `Failure err` on error instead of returning an `Error err` result.
 
 Semantics
 ---------
@@ -67,10 +67,12 @@ The following table summarizes the correspondence between OCaml types and JSON v
 | `string`, `bytes`      | String     |                                  |
 | `char`                 | String     | Strictly one character in length |
 | `list`, `array`        | Array      |                                  |
+| A tuple                | Array      |                                  |
 | `ref`                  | 'a         |                                  |
 | `option`               | Null or 'a |                                  |
 | A record               | Object     |                                  |
 | `Yojson.Safe.t`        | any        | Identity transformation          |
+| `unit`                 | Null       |                                  |
 
 Variants (regular and polymorphic) are represented using arrays; the first element is a string with the name of the constructor, the rest are the arguments. Note that the implicit tuple in a polymorphic variant is flattened. For example:
 
@@ -174,7 +176,7 @@ type foo = {
  fvalue : float;
  svalue : string [@key "@svalue_json"];
  ivalue : int;
-} [@@deriving to_yojson { strict = false, fields = true } ]
+} [@@deriving to_yojson { strict = false, meta = true } ]
 end
 ```
 

--- a/src/ppx_deriving_yojson.cppo.ml
+++ b/src/ppx_deriving_yojson.cppo.ml
@@ -385,7 +385,7 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let ty = Typ.poly poly_vars (polymorphize_ser [%type: [%t typ] -> Yojson.Safe.t]) in
       let default_fun =
         let type_path = String.concat "." (path @ [type_decl.ptype_name.txt]) in
-        let e_type_path = Exp.constant (Pconst_string (type_path, None)) in
+        let e_type_path = Exp.constant (Const.string type_path) in
         [%expr fun _ ->
           invalid_arg ("to_yojson: Maybe a [@@deriving yojson] is missing when extending the type "^
                        [%e e_type_path])]


### PR DESCRIPTION
This pull-request is supposed to work with
https://github.com/ocaml-ppx/ppx_deriving/pull/222/commits/592a9dff07dd919481a0e677029aacb9a0dfd890

The purpose is to be able to make a minor release (both for ppx_deriving and its rev-dependencies) with just OCaml 4.11.0 support before making the major ppxlib release.