### PR TITLE
Release 3.5.3 to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex ./.travis-docker.sh
 env:
   global:
-  - PINS="ppx_deriving_yojson:. ppx_deriving:git://github.com/ocaml-ppx/ppx_deriving.git ocaml-migrate-parsetree:git://github.com/ocaml-ppx/ocaml-migrate-parsetree.git"
+  - PINS="ppx_deriving_yojson:. ppx_deriving.dev:git://github.com/ocaml-ppx/ppx_deriving.git"
+  - PACKAGE="ppx_deriving_yojson"
+  - DISTRO="ubuntu-16.04"
   matrix:
-  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.11.0+trunk" OCAML_BETA="enable"
-  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.10"
-  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.09"
-  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.08"
-  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.07"
-  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.06"
-  - PACKAGE="ppx_deriving_yojson" DISTRO="ubuntu-16.04"    OCAML_VERSION="4.05"
+  - OCAML_VERSION="4.11.0+trunk" OCAML_BETA="enable"
+  - OCAML_VERSION="4.10"
+  - OCAML_VERSION="4.09"
+  - OCAML_VERSION="4.08"
+  - OCAML_VERSION="4.07"
+  - OCAML_VERSION="4.06"
+  - OCAML_VERSION="4.05"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+3.5.3
+-----
+
+  * Support for OCaml 4.11 (requires feature from `ppx_deriving.4.5`)
+    (#122)
+    Thierry Martinez
+  * Documentation improvements
+    (#115)
+    Olivier Andrieu
+
 3.5.2
 -----
 

--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -17,7 +17,7 @@ depends: [
   "yojson" {>= "1.6.0" & < "2.0.0"}
   "result"
   "ppx_deriving" {>= "5.0"}
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.9.0" & < "0.14.0"}
   "ounit" {with-test & >= "2.0.0"}
 ]
 synopsis:

--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -7,21 +7,18 @@ bug-reports: "https://github.com/ocaml-ppx/ppx_deriving_yojson/issues"
 dev-repo: "git://github.com/ocaml-ppx/ppx_deriving_yojson.git"
 tags: [ "syntax" "json" ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name] {with-test}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.0"}
   "yojson" {>= "1.6.0" & < "2.0.0"}
   "result"
-  "ppx_deriving" {>= "4.0" & < "5.0"}
+  "ppx_deriving" {>= "5.0"}
   "ppxlib" {>= "0.9.0"}
-  "dune"
-  "ounit"        {with-test & >= "2.0.0"}
-]
-conflicts: [
-  "ppx_deriving" {= "4.2"}
+  "ounit" {with-test & >= "2.0.0"}
 ]
 synopsis:
   "JSON codec generator for OCaml"


### PR DESCRIPTION
Simply a port of https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/124 to the `master` branch.

The only changes with regards to #124 are:
* `ppx_deriving_yojson` now requires `ppx_deriving >= 5.0` (with ppxlib, not released yet)
* Dropped the OCaml 4.04 support (as `ppx_deriving.5.0` does not support this version anymore)