### PR TITLE
Capture equality operator in the runtime

### DIFF
--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -321,7 +321,7 @@ let ser_str_of_record ~loc varname labels =
       | None ->
           [%expr [%e result] :: fields]
       | Some default ->
-          [%expr if [%e field] = [%e default] then fields else [%e result] :: fields])
+          [%expr if Pervasives.(=) [%e field] [%e default] then fields else [%e result] :: fields])
   in
   let assoc =
     List.fold_left

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -505,6 +505,18 @@ let test_int_redefined ctxt =
   let expected = `Int 1 in
   assert_equal ~ctxt ~printer:show_json expected M.x
 
+let test_equality_redefined ctxt =
+  let module M = struct
+    let (=) : int -> int -> bool = fun a b -> a = b
+    let _ = 1 = 1 (* just dummy usage of `=` to suppress compiler warning *)
+
+    type t = {field : int option [@default None]} [@@deriving to_yojson]
+    let x = {field = Some 42}
+  end
+  in
+  let expected = `Assoc ([("field", `Int (42))]) in
+  assert_equal ~ctxt ~printer:show_json expected M.(to_yojson x)
+
 let suite = "Test ppx_yojson" >::: [
     "test_unit"      >:: test_unit;
     "test_int"       >:: test_int;
@@ -537,6 +549,7 @@ let suite = "Test ppx_yojson" >::: [
     "test_opentype"  >:: test_opentype;
     "test_recursive" >:: test_recursive;
     "test_int_redefined" >:: test_int_redefined;
+    "test_equality_redefined" >:: test_equality_redefined;
   ]
 
 let _ =


### PR DESCRIPTION
I recently hit a problem with the equality operator being captured from the environment. For example, recent versions of [`base`](https://github.com/janestreet/base) redefine the operator so it only accepts `int`s, so this code

```ocaml
open Base

type t = {f : int option [@default None]} [@@deriving to_yojson]
```

fails with something like this

```
File "tmp.ml", line 3, characters 0-64:
3 | type t = {f : int option [@default None]} [@@deriving to_yojson]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This expression has type Base.int option
       but an expression was expected of type int
```

It seems that the default value is needed for the failure to occur.