### PR TITLE
Fix issues at runtime when the Pervasives module is redefined

### DIFF
--- a/src/ppx_deriving_yojson_runtime.mli
+++ b/src/ppx_deriving_yojson_runtime.mli
@@ -1,3 +1,5 @@
+include module type of Ppx_deriving_runtime
+
 type 'a error_or = ('a, string) Result.result
 
 val ( >>= ) : 'a error_or -> ('a -> 'b error_or) -> 'b error_or
@@ -8,16 +10,3 @@ val map_bind : ('a -> 'b error_or) -> 'b list -> 'a list -> 'b list error_or
     computes it tail-recursively so that large list lengths don't
     cause a stack overflow *)
 val safe_map : ('a -> 'b) -> 'a list -> 'b list
-
-module List : (module type of List)
-module String : (module type of String)
-module Bytes : (module type of Bytes)
-module Int32 : (module type of Int32)
-module Int64 : (module type of Int64)
-module Nativeint : (module type of Nativeint)
-module Array : (module type of Array)
-module Result : sig
-  type ('a, 'b) result = ('a, 'b) Result.result =
-    | Ok of 'a
-    | Error of 'b
-end

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -507,6 +507,10 @@ let test_int_redefined ctxt =
 
 let test_equality_redefined ctxt =
   let module M = struct
+    module Pervasives = struct
+      let (=) : int -> int -> bool = fun a b -> a = b
+      let _ = 1 = 1 (* just dummy usage of `=` to suppress compiler warning *)
+    end
     let (=) : int -> int -> bool = fun a b -> a = b
     let _ = 1 = 1 (* just dummy usage of `=` to suppress compiler warning *)
 


### PR DESCRIPTION
While writing the changelog for the release I realized that my modification of https://github.com/ocaml-ppx/ppx_deriving_yojson/pull/126 isn't correct if the user has redefined/shadowed the `Pervasives` module.

Previously, only a handful of modules exported by `Ppx_deriving_runtime` were reexported by `Ppx_deriving_yojson_runtime`, with this change the whole interface is being pulled up.