### PR TITLE
Revert #128 and reapply the original fix from #126

### DIFF
--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -321,7 +321,7 @@ let ser_str_of_record ~loc varname labels =
       | None ->
           [%expr [%e result] :: fields]
       | Some default ->
-          [%expr if Pervasives.(=) [%e field] [%e default] then fields else [%e result] :: fields])
+          [%expr if [%e field] = [%e default] then fields else [%e result] :: fields])
   in
   let assoc =
     List.fold_left

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -300,6 +300,11 @@ and desu_expr_of_only_typ ~path typ =
     raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                  deriver (Ppx_deriving.string_of_core_type typ)
 
+(* TODO: Do not wrap runtime around [@default ...].
+   We do currently and for instance the following doesn't currently work:
+   module List = struct let x = [1; 2] end
+   type t = {field : int list [@default List.x]} [@@deriving to_yojson]
+*)
 let wrap_runtime decls =
   Ppx_deriving.sanitize ~module_:(Lident "Ppx_deriving_yojson_runtime") decls
 

--- a/src/ppx_deriving_yojson_runtime.mli
+++ b/src/ppx_deriving_yojson_runtime.mli
@@ -1,5 +1,3 @@
-include module type of Ppx_deriving_runtime
-
 type 'a error_or = ('a, string) Result.result
 
 val ( >>= ) : 'a error_or -> ('a -> 'b error_or) -> 'b error_or
@@ -10,3 +8,17 @@ val map_bind : ('a -> 'b error_or) -> 'b list -> 'a list -> 'b list error_or
     computes it tail-recursively so that large list lengths don't
     cause a stack overflow *)
 val safe_map : ('a -> 'b) -> 'a list -> 'b list
+
+val ( = ) : 'a -> 'a -> bool (* NOTE: Used for [@default ...] *)
+module List : (module type of List)
+module String : (module type of String)
+module Bytes : (module type of Bytes)
+module Int32 : (module type of Int32)
+module Int64 : (module type of Int64)
+module Nativeint : (module type of Nativeint)
+module Array : (module type of Array)
+module Result : sig
+  type ('a, 'b) result = ('a, 'b) Result.result =
+    | Ok of 'a
+    | Error of 'b
+end

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -505,6 +505,22 @@ let test_int_redefined ctxt =
   let expected = `Int 1 in
   assert_equal ~ctxt ~printer:show_json expected M.x
 
+(* TODO: Make this work *)
+(*
+let test_list_redefined ctxt =
+  let module M = struct
+    type redef_list =
+      | []
+      | (::) of int * int
+
+    type t = {field : int list} [@@deriving to_yojson]
+    let x = {field = List.([1;2])}
+  end
+  in
+  let expected = `List [`Int 1; `Int 2] in
+  assert_equal ~ctxt ~printer:show_json expected M.x
+*)
+
 let test_equality_redefined ctxt =
   let module M = struct
     module Pervasives = struct

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -510,11 +510,13 @@ let test_equality_redefined ctxt =
     module Pervasives = struct
       let (=) : int -> int -> bool = fun a b -> a = b
       let _ = 1 = 1 (* just dummy usage of `=` to suppress compiler warning *)
+
+      let never_gonna_be_in_pervasives = None
     end
     let (=) : int -> int -> bool = fun a b -> a = b
     let _ = 1 = 1 (* just dummy usage of `=` to suppress compiler warning *)
 
-    type t = {field : int option [@default None]} [@@deriving to_yojson]
+    type t = {field : int option [@default Pervasives.never_gonna_be_in_pervasives]} [@@deriving to_yojson]
     let x = {field = Some 42}
   end
   in


### PR DESCRIPTION
Frama-C failed with my fix so I'm reapplying @martinslota's original fix from #126 (sorry for that)
```
#=== ERROR while compiling frama-c.21.1 =======================================#
# context              2.0.7 | linux/x86_64 | ocaml-base-compiler.4.11.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.11/.opam-switch/build/frama-c.21.1
# command              /usr/bin/make -j72
# exit-code            2
# env-file             ~/.opam/log/frama-c-25-632471.env
# output-file          ~/.opam/log/frama-c-25-632471.out
### output ###
# File "src/plugins/markdown-report/sarif.ml", line 335, characters 30-43:
# 335 |     stack: (Stack.t [@default Stack.default]);
#                                     ^^^^^^^^^^^^^
# Error: Unbound value Stack.default
```
After that I suppose this is fine to re-release 3.6.0.

Side-note: I added a few TODO comments as currently `[@default ...]` is broken when passed a value from a module also defined in `Ppx_deriving_runtime` (currently `List`, `String`, `Bytes`, `Int32`, `Int64`, `NativeInt`, `Array`, `Result` as well as several short functions and types).
At best this is going to fail to compile, at worst the values/functions used are not going to have the same behaviour as expected and might enable nasty bugs.
I do not have enough knowledge of the codebase and on how to do that properly but since it was like this before I suppose this is fine to let as is for now.