### PR TITLE
Add ppxlib as a direct dependency for ppx_deriving_yojson

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -9,7 +9,7 @@
  (name ppx_deriving_yojson)
  (public_name ppx_deriving_yojson)
  (synopsis "[@@deriving yojson]")
- (libraries ppx_deriving.api)
+ (libraries ppxlib ppx_deriving.api)
  (preprocess (pps ppxlib.metaquot))
  (ppx_runtime_libraries ppx_deriving_yojson_runtime yojson)
  (modules ppx_deriving_yojson)


### PR DESCRIPTION
[ppx_deriving_yojson.ml](https://github.com/ocaml-ppx/ppx_deriving_yojson/blob/d0abe462de8bab52d763eeafd751e8ea1ba211ac/src/ppx_deriving_yojson.ml#L1) is directly using `Ppxlib`, so it should be declared as a direct dependency instead of being provided transitively through `ppx_deriving`.