### PR TITLE
Add quoter

### DIFF
--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -886,7 +886,7 @@ let on_str_decls f ~options ~path type_decls =
 let on_sig_decls f ~options ~path type_decls =
   List.concat (List.map (f ~options ~path) type_decls)
 
-(* outside of register-create to use our sanitize, not opened one from Ppx_deriving *)
+(* Note: we are careful to call our sanitize function here, not Ppx_deriving.sanitize. *)
 let ser_core_expr_of_typ typ =
   let quoter = Ppx_deriving.create_quoter () in
   let typ = Ppx_deriving.strong_type_of_type typ in

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -322,6 +322,7 @@ let ser_str_of_record quoter ~loc varname labels =
       | None ->
           [%expr [%e result] :: fields]
       | Some default ->
+          let default = [%expr ([%e default] : [%t pld_type])] in
           [%expr if [%e field] = [%e Ppx_deriving.quote ~quoter default] then fields else [%e result] :: fields])
   in
   let assoc =
@@ -539,7 +540,9 @@ let desu_str_of_record quoter ~loc ~is_strict ~error ~path wrap_record labels =
     labels |> List.map (fun { pld_name = { txt = name }; pld_type; pld_attributes } ->
       match attr_default (pld_type.ptyp_attributes @ pld_attributes) with
       | None   -> error (path @ [name])
-      | Some x -> [%expr Result.Ok [%e Ppx_deriving.quote ~quoter x]])
+      | Some default ->
+        let default = [%expr ([%e default] : [%t pld_type])] in
+        [%expr Result.Ok [%e Ppx_deriving.quote ~quoter default]])
   in
   [%expr
     function

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -301,11 +301,6 @@ and desu_expr_of_only_typ quoter ~path typ =
     raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                  deriver (Ppx_deriving.string_of_core_type typ)
 
-(* TODO: Do not wrap runtime around [@default ...].
-   We do currently and for instance the following doesn't currently work:
-   module List = struct let x = [1; 2] end
-   type t = {field : int list [@default List.x]} [@@deriving to_yojson]
-*)
 let wrap_runtime decls =
   Ppx_deriving.sanitize ~module_:(Lident "Ppx_deriving_yojson_runtime") decls
 

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -341,7 +341,6 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   match type_decl.ptype_kind with
   | Ptype_open -> begin
-    (* TODO: sanitize something in this case? *)
     let to_yojson_name = Ppx_deriving.mangle_type_decl (`Suffix "to_yojson") type_decl in
     let mod_name = Ppx_deriving.mangle_type_decl
       (`PrefixSuffix ("M", "to_yojson")) type_decl
@@ -351,9 +350,9 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
       let ser = ser_expr_of_typ quoter manifest in
       let lid = Ppx_deriving.mangle_lid (`PrefixSuffix ("M", "to_yojson")) lid in
       let orig_mod = Mod.ident (mknoloc lid) in
+      let poly_ser = polymorphize [%expr ([%e sanitize ~quoter ser] : [%t typ] -> Yojson.Safe.t)] in
       ([Str.module_ (Mb.mk (mod_mknoloc mod_name) orig_mod)],
-       [Vb.mk (pvar to_yojson_name)
-              (polymorphize [%expr ([%e ser] : [%t typ] -> Yojson.Safe.t)])],
+       [Vb.mk (pvar to_yojson_name) poly_ser],
        [])
     | Some _ ->
       raise_errorf ~loc "%s: extensible type manifest should be a type name" deriver
@@ -561,7 +560,6 @@ let desu_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   match type_decl.ptype_kind with
   | Ptype_open -> begin
-    (* TODO: sanitize something in this case? *)
     let of_yojson_name = Ppx_deriving.mangle_type_decl (`Suffix "of_yojson") type_decl in
     let mod_name = Ppx_deriving.mangle_type_decl
       (`PrefixSuffix ("M", "of_yojson")) type_decl

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -547,6 +547,10 @@ struct
   end
 
   type result_list = Result.t list [@@deriving yojson]
+
+  (* sanitize [@default ...] *)
+  module List = struct let x = [1; 2] end
+  type t = {field : int list [@default List.x]} [@@deriving to_yojson]
 end
 
 let suite = "Test ppx_yojson" >::: [

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -543,10 +543,10 @@ module Sanitize =
 struct
   module Result =
   struct
-    type t = A [@@deriving to_yojson]
+    type t = A [@@deriving yojson]
   end
 
-  type result_list = Result.t list [@@deriving to_yojson]
+  type result_list = Result.t list [@@deriving yojson]
 end
 
 let suite = "Test ppx_yojson" >::: [

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -539,6 +539,16 @@ let test_equality_redefined ctxt =
   let expected = `Assoc ([("field", `Int (42))]) in
   assert_equal ~ctxt ~printer:show_json expected M.(to_yojson x)
 
+module Sanitize =
+struct
+  module Result =
+  struct
+    type t = A [@@deriving to_yojson]
+  end
+
+  type result_list = Result.t list [@@deriving to_yojson]
+end
+
 let suite = "Test ppx_yojson" >::: [
     "test_unit"      >:: test_unit;
     "test_int"       >:: test_int;

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -543,7 +543,7 @@ module Sanitize =
 struct
   module Result =
   struct
-    type t = A [@@deriving yojson]
+    type t = MyResult [@@deriving yojson]
   end
 
   type result_list = Result.t list [@@deriving yojson]
@@ -551,6 +551,8 @@ struct
   (* sanitize [@default ...] *)
   module List = struct let x = [1; 2] end
   type t = {field : int list [@default List.x]} [@@deriving to_yojson]
+
+  type t2 = {my: Result.t [@default MyResult]} [@@deriving yojson]
 end
 
 let suite = "Test ppx_yojson" >::: [


### PR DESCRIPTION
I noticed that this deriver didn't work with a custom `Result` module (which is completely unrelated to the standard library one) and found out that no quoter is being used for sanitization. This PR adds that and should thus fix #81.

By also sanitizing the content of `[@default ...]` this fixes #132 as well.