### PR TITLE
Ppxlib.0.26.0 compatibility

### DIFF
--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -17,7 +17,7 @@ depends: [
   "yojson" {>= "1.6.0" & < "2.0.0"}
   "result"
   "ppx_deriving" {>= "5.1"}
-  "ppxlib" {>= "0.14.0"}
+  "ppxlib" {>= "0.26.0"}
   "ounit" {with-test & >= "2.0.0"}
 ]
 synopsis:

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -451,9 +451,7 @@ let ser_str_of_type_ext ~options ~path:_ ({ ptyext_path = { loc }} as type_ext) 
           (* nothing to do, since the constructor must be handled in original
              constructor declaration *)
           acc_cases
-        | Pext_decl (_ :: _, _, _) ->
-          raise_errorf ~loc "%s: Explicit binders for type variables not supported" deriver
-        | Pext_decl ([], pext_args, _) ->
+        | Pext_decl (_, pext_args, _) ->
           let json_name = attr_name name' pext_attributes in
           let case =
             match pext_args with
@@ -680,9 +678,7 @@ let desu_str_of_type_ext ~options ~path ({ ptyext_path = { loc } } as type_ext) 
           (* nothing to do since it must have been handled in the original
              constructor declaration *)
           acc_cases
-        | Pext_decl (_ :: _, _, _) ->
-          raise_errorf ~loc "%s: Explicit binders for type variables not allowed" deriver
-        | Pext_decl ([], pext_args, _) ->
+        | Pext_decl (_, pext_args, _) ->
           let case =
             match pext_args with
             | Pcstr_tuple(args) ->

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -451,7 +451,9 @@ let ser_str_of_type_ext ~options ~path:_ ({ ptyext_path = { loc }} as type_ext) 
           (* nothing to do, since the constructor must be handled in original
              constructor declaration *)
           acc_cases
-        | Pext_decl (pext_args, _) ->
+        | Pext_decl (_ :: _, _, _) ->
+          raise_errorf ~loc "%s: Explicit binders for type variables not supported" deriver
+        | Pext_decl ([], pext_args, _) ->
           let json_name = attr_name name' pext_attributes in
           let case =
             match pext_args with
@@ -678,7 +680,9 @@ let desu_str_of_type_ext ~options ~path ({ ptyext_path = { loc } } as type_ext) 
           (* nothing to do since it must have been handled in the original
              constructor declaration *)
           acc_cases
-        | Pext_decl (pext_args, _) ->
+        | Pext_decl (_ :: _, _, _) ->
+          raise_errorf ~loc "%s: Explicit binders for type variables not allowed" deriver
+        | Pext_decl ([], pext_args, _) ->
           let case =
             match pext_args with
             | Pcstr_tuple(args) ->


### PR DESCRIPTION
This is a patch PR to make the PPX compatible with ppxlib.0.26.0 which has bumped the AST to 4.14/5.00.