### PR TITLE
Use ounit2 directly

### DIFF
--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -18,7 +18,7 @@ depends: [
   "result"
   "ppx_deriving" {>= "5.1"}
   "ppxlib" {>= "0.26.0"}
-  "ounit" {with-test & >= "2.0.0"}
+  "ounit2" {with-test}
 ]
 synopsis:
   "JSON codec generator for OCaml"

--- a/src_test/dune
+++ b/src_test/dune
@@ -1,6 +1,6 @@
 (executable
  (name test_ppx_yojson)
- (libraries oUnit result)
+ (libraries ounit2 result)
  (preprocess (pps ppx_deriving.show ppx_deriving_yojson))
  (flags (:standard -w -9-39-27-34-37)))
 


### PR DESCRIPTION
Ounit 1 is a transition package that now only depends on ounit2, so to curb dependencies and simplify, this removes a link in the dependency chain.