### PR TITLE
Port to ppxlib registration and attributes

### DIFF
--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -17,7 +17,7 @@ depends: [
   "yojson" {>= "1.6.0" & < "2.0.0"}
   "result"
   "ppx_deriving" {>= "5.1"}
-  "ppxlib" {>= "0.26.0"}
+  "ppxlib" {>= "0.30.0"}
   "ounit2" {with-test}
 ]
 synopsis:

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -903,7 +903,6 @@ let make_gen f =
 let _to_deriving: Deriving.t =
   Deriving.add
     "to_yojson"
-    ~extension:(fun ~loc:_ ~path:_ -> ser_core_expr_of_typ)
     ~str_type_decl:(make_gen (fun ~options ~path (_, type_decls) ->
         structure (on_str_decls str_of_type_to_yojson) ~options ~path type_decls
       ))
@@ -916,7 +915,6 @@ let _to_deriving: Deriving.t =
 let _of_deriving: Deriving.t =
   Deriving.add
     "of_yojson"
-    ~extension:(fun ~loc:_ ~path:_ -> desu_core_expr_of_typ)
     ~str_type_decl:(make_gen (fun ~options ~path (_, type_decls) ->
         structure (on_str_decls str_of_type_of_yojson) ~options ~path type_decls
       ))
@@ -938,3 +936,18 @@ let _deriving: Deriving.t =
       ))
     ~str_type_ext:(make_gen str_of_type_ext)
     ~sig_type_ext:(make_gen sig_of_type_ext)
+
+(* custom extensions such that "derive"-prefixed also works *)
+let to_derive_extension =
+  Extension.V3.declare "derive.to_yojson" Extension.Context.expression
+    Ast_pattern.(ptyp __) (fun ~ctxt:_ -> ser_core_expr_of_typ)
+let of_derive_extension =
+  Extension.V3.declare "derive.of_yojson" Extension.Context.expression
+    Ast_pattern.(ptyp __) (fun ~ctxt:_ -> desu_core_expr_of_typ)
+let _derive_transformation =
+  Driver.register_transformation
+    deriver
+    ~rules:[
+      Context_free.Rule.extension to_derive_extension;
+      Context_free.Rule.extension of_derive_extension;
+    ]

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -61,11 +61,6 @@ type options = {
   want_exn: bool;
 }
 
-let ebool: _ Ast_pattern.t -> _ Ast_pattern.t =
-  Ast_pattern.map1 ~f:(function
-    | [%expr true] -> true
-    | [%expr false] -> false
-    | _ -> failwith "not bool")
 let args () = Deriving.Args.(empty +> arg "strict" (ebool __) +> arg "meta" (ebool __) +> arg "exn" (ebool __))
 
 let poly_fun names expr =

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -304,8 +304,7 @@ and desu_expr_of_only_typ ~quoter ~path typ =
 let sanitize ~quoter decls =
   Ppx_deriving.sanitize ~quoter ~module_:(Lident "Ppx_deriving_yojson_runtime") decls
 
-let ser_type_of_decl ~options ~path:_ type_decl =
-  ignore (parse_options options);
+let ser_type_of_decl ~options:_ ~path:_ type_decl =
   let loc = type_decl.ptype_loc in
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
   let polymorphize = Ppx_deriving.poly_arrow_of_type_decl
@@ -336,7 +335,6 @@ let ser_str_of_record ~quoter ~loc varname labels =
 
 
 let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
-  ignore (parse_options options);
   let quoter = Ppx_deriving.create_quoter () in
   let polymorphize = Ppx_deriving.poly_fun_of_type_decl type_decl in
   let typ = Ppx_deriving.core_type_of_type_decl type_decl in
@@ -440,8 +438,7 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
      [Str.value Nonrecursive [Vb.mk (pvar "_") [%expr [%e evar var_s]]] ]
      )
 
-let ser_str_of_type_ext ~options ~path:_ ({ ptyext_path = { loc }} as type_ext) =
-  ignore (parse_options options);
+let ser_str_of_type_ext ~options:_ ~path:_ ({ ptyext_path = { loc }} as type_ext) =
   let quoter = Ppx_deriving.create_quoter () in
   let serializer =
     let pats =
@@ -496,8 +493,7 @@ let error_or typ =
   let loc = typ.ptyp_loc in
   [%type: [%t typ] Ppx_deriving_yojson_runtime.error_or]
 
-let desu_type_of_decl_poly ~options ~path:_ type_decl type_ =
-  ignore (parse_options options);
+let desu_type_of_decl_poly ~options:_ ~path:_ type_decl type_ =
   let loc = type_decl.ptype_loc in
   let polymorphize = Ppx_deriving.poly_arrow_of_type_decl
                        (fun var -> [%type: Yojson.Safe.t -> [%t error_or var]]) type_decl in
@@ -554,7 +550,7 @@ let desu_str_of_record ~quoter ~loc ~is_strict ~error ~path wrap_record labels =
 
 
 let desu_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
-  let { is_strict; want_exn; _ } = parse_options options in
+  let { is_strict; want_exn; _ } = options in
   let quoter = Ppx_deriving.create_quoter () in
   let path = path @ [type_decl.ptype_name.txt] in
   let error path = [%expr Result.Error [%e str (String.concat "." path)]] in
@@ -667,8 +663,7 @@ let desu_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
         ;Str.value Nonrecursive [Vb.mk (pvar "_") [%expr [%e evar var_s_exn]]]])
      )
 
-let desu_str_of_type_ext ~options ~path ({ ptyext_path = { loc } } as type_ext) =
-  ignore(parse_options options);
+let desu_str_of_type_ext ~options:_ ~path ({ ptyext_path = { loc } } as type_ext) =
   let quoter = Ppx_deriving.create_quoter () in
   let desurializer =
     let pats =
@@ -750,7 +745,7 @@ let ser_sig_of_type ~options ~path type_decl =
 let ser_sig_of_type_ext ~options:_ ~path:_ _type_ext = []
 
 let desu_sig_of_type ~options ~path type_decl =
-  let { want_exn; _ } = parse_options options in
+  let { want_exn; _ } = options in
   let of_yojson =
     Sig.value (Val.mk (mknoloc (Ppx_deriving.mangle_type_decl (`Suffix "of_yojson") type_decl))
                       (desu_type_of_decl ~options ~path type_decl))
@@ -794,7 +789,7 @@ let desu_sig_of_type ~options ~path type_decl =
 let desu_sig_of_type_ext ~options:_ ~path:_ _type_ext = []
 
 let yojson_str_fields ~options ~path:_ type_decl =
-  let { want_meta; _ } = parse_options options in
+  let { want_meta; _ } = options in
   match want_meta, type_decl.ptype_kind with
   | false, _ | true, Ptype_open -> []
   | true, kind ->
@@ -818,7 +813,7 @@ let yojson_str_fields ~options ~path:_ type_decl =
     | _ -> []
 
 let yojson_sig_fields ~options ~path:_ type_decl =
-  let { want_meta; _ } = parse_options options in
+  let { want_meta; _ } = options in
   match want_meta, type_decl.ptype_kind with
   | false, _ | true, Ptype_open -> []
   | true, kind ->
@@ -871,6 +866,7 @@ let sig_of_type_ext ~options ~path type_ext =
   (desu_sig_of_type_ext ~options ~path type_ext)
 
 let structure f ~options ~path type_ =
+  let options = parse_options options in
   let (pre, vals, post) = f ~options ~path type_ in
   match vals with
   | [] -> pre @ post
@@ -884,6 +880,7 @@ let on_str_decls f ~options ~path type_decls =
   (List.concat pre, List.concat vals, List.concat post)
 
 let on_sig_decls f ~options ~path type_decls =
+  let options = parse_options options in
   List.concat (List.map (f ~options ~path) type_decls)
 
 (* Note: we are careful to call our sanitize function here, not Ppx_deriving.sanitize. *)

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -923,9 +923,7 @@ let _of_deriving: Deriving.t =
     ~str_type_ext:(Deriving.Generator.V2.make (args ()) (convert_args desu_str_of_type_ext))
     ~sig_type_ext:(Deriving.Generator.V2.make (args ()) (convert_args desu_sig_of_type_ext))
 
-(* Not just alias because yojson also has meta *)
-(* let _deriving: Deriving.t =
-  Deriving.add_alias "yojson" [_to_deriving; _of_deriving] *)
+(* Not just alias because yojson also has meta (without its own deriver name) *)
 let _deriving: Deriving.t =
   Deriving.add
     "yojson"

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -958,10 +958,10 @@ let _deriving: Deriving.t =
 
 (* custom extensions such that "derive"-prefixed also works *)
 let to_derive_extension =
-  Extension.V3.declare "derive.to_yojson" Extension.Context.expression
+  Extension.V3.declare "ppx_deriving_yojson.derive.to_yojson" Extension.Context.expression
     Ast_pattern.(ptyp __) (fun ~ctxt:_ -> ser_core_expr_of_typ)
 let of_derive_extension =
-  Extension.V3.declare "derive.of_yojson" Extension.Context.expression
+  Extension.V3.declare "ppx_deriving_yojson.derive.of_yojson" Extension.Context.expression
     Ast_pattern.(ptyp __) (fun ~ctxt:_ -> desu_core_expr_of_typ)
 let _derive_transformation =
   Driver.register_transformation

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -19,6 +19,9 @@ let show_error_or =
   end in
   M.show_error_or
 
+let show_keys keys =
+  Format.asprintf "[%a]" (Format.pp_print_list ~pp_sep:(fun fmt () -> Format.pp_print_string fmt "; ") Format.pp_print_string) keys
+
 let assert_roundtrip pp_obj to_json of_json obj str =
   let json = Yojson.Safe.from_string str in
   let cleanup json = Yojson.Safe.(json |> to_string |> from_string) in
@@ -64,7 +67,7 @@ type pvd = [ pva | pvb | int pvc ]
 type v  = A | B of int | C of int * string
 [@@deriving show, yojson]
 type r  = { x : int; y : string }
-[@@deriving show, yojson]
+[@@deriving show, yojson { meta = true }]
 type rv = RA | RB of int | RC of int * string | RD of { z : string }
 [@@deriving show, yojson]
 
@@ -204,7 +207,8 @@ let test_var _ctxt =
 
 let test_rec _ctxt =
   assert_roundtrip pp_r r_to_yojson r_of_yojson
-                   {x=42; y="foo"} "{\"x\":42,\"y\":\"foo\"}"
+                   {x=42; y="foo"} "{\"x\":42,\"y\":\"foo\"}";
+  assert_equal ~printer:show_keys ["x"; "y"] Yojson_meta_r.keys
 
 let test_recvar _ctxt =
   assert_roundtrip pp_rv rv_to_yojson rv_of_yojson
@@ -220,11 +224,12 @@ type geo = {
   lat : float [@key "Latitude"]  ;
   lon : float [@key "Longitude"] ;
 }
-[@@deriving yojson, show]
+[@@deriving yojson { meta = true }, show]
 let test_key _ctxt =
   assert_roundtrip pp_geo geo_to_yojson geo_of_yojson
                    {lat=35.6895; lon=139.6917}
-                   "{\"Latitude\":35.6895,\"Longitude\":139.6917}"
+                   "{\"Latitude\":35.6895,\"Longitude\":139.6917}";
+  assert_equal ~printer:show_keys ["Latitude"; "Longitude"] Yojson_meta_geo.keys
 
 let test_field_err _ctxt =
   assert_equal ~printer:(show_error_or pp_geo)


### PR DESCRIPTION
Analogous to https://github.com/ocaml-ppx/ppx_deriving/pull/263. This doesn't necessarily depend on that PR, but some of the same criticism applies.

~~In particular the point about `[%derive.to_yojson: ...]` and `[%derive.of_yojson: ...]` being unsupported through ppxlib directly. According to sherlocode, only ocurrent uses one of these.~~
Nevermind, the support can be preserved using a custom extension.