### PR TITLE
Support alternative representations of variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+unreleased
+----------
+
+  * Support alternative representations of variants
+    (#155)
+    Anna Danilkin
+
 3.10.0
 ------
 


### PR DESCRIPTION
The only current representation has problems with readability and interoperability with JSON libraries for other languages, such as:
* Rust with serde: https://serde.rs/enum-representations.html
* Python with pyserde: https://github.com/yukinarit/pyserde/blob/main/docs/en/union.md
* Haskell with Aeson: https://hackage.haskell.org/package/aeson-2.2.1.0/docs/Data-Aeson.html#t:SumEncoding

Closes #27, #32.