### PR TITLE
Add missing dependency on result

### DIFF
--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -18,6 +18,7 @@ depends: [
   "yojson" {>= "1.6.0"}
   "ppx_deriving" {>= "5.1"}
   "ppxlib" {>= "0.26.0"}
+  "result"
   "ounit2" {with-test}
 ]
 synopsis:


### PR DESCRIPTION
ppx_deriving_yojson depends on the result compatibility package but wasn't declaring this dependency explicitly.

This used to work because ppx_deriving also depended on result but since it will not be the case anymore starting from ppx_deriving.6.0.0, this needs to be updated.

It's likely that we will drop this dependency for the same reasons ppx_deriving did but in the meantime it does not cost much to update our opam file.