### PR TITLE
Prepare for 5.2 AST in Ppxlib 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+unreleased
+----------
+
+  * Bump to ppxlib.0.36.0, 5.2 AST
+    (#160)
+    @patricoferris
+  * Fix more `Poly_typ ([], ...)` nodes generation
+    #160
+    @NathanReb
+
 3.9.1
 -----
 
@@ -5,10 +15,6 @@
     de/serializer for open types. These are rejected by OCaml 5.3 onward.
     (#162)
     @NathanReb
-
-  * Bump to ppxlib.0.36.0, 5.2 AST
-    (#160)
-    @patricoferris
 
 3.9.0
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
     (#162)
     @NathanReb
 
+  * Bump to ppxlib.0.36.0, 5.2 AST
+    (#160)
+    @patricoferris
+
 3.9.0
 -----
 
@@ -18,7 +22,7 @@
 
   * Port deriver to ppxlib
     (#149)
-    Simmo Saan 
+    Simmo Saan
 
 3.7.0
 -----

--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.0"}
   "yojson" {>= "1.6.0"}
   "ppx_deriving" {>= "5.1"}
-  "ppxlib" {>= "0.35.0"}
+  "ppxlib" {>= "0.36.0"}
   "ounit2" {with-test}
 ]
 synopsis:

--- a/ppx_deriving_yojson.opam
+++ b/ppx_deriving_yojson.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.0"}
   "yojson" {>= "1.6.0"}
   "ppx_deriving" {>= "5.1"}
-  "ppxlib" {>= "0.30.0"}
+  "ppxlib" {>= "0.35.0"}
   "ounit2" {with-test}
 ]
 synopsis:

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -148,7 +148,7 @@ and ser_expr_of_only_typ ~quoter typ =
     Exp.function_ cases
   | { ptyp_desc = Ptyp_var name } -> [%expr ([%e evar ("poly_"^name)] : _ -> Yojson.Safe.t)]
   | { ptyp_desc = Ptyp_alias (typ, name) } ->
-    [%expr fun x -> [%e evar ("poly_"^name)] x; [%e ser_expr_of_typ typ] x]
+    [%expr fun x -> [%e evar ("poly_"^name.txt)] x; [%e ser_expr_of_typ typ] x]
   | { ptyp_desc = Ptyp_poly (names, typ) } ->
      poly_fun names (ser_expr_of_typ typ)
   | { ptyp_loc } ->
@@ -279,7 +279,7 @@ and desu_expr_of_only_typ ~quoter ~path typ =
   | { ptyp_desc = Ptyp_var name } ->
     [%expr ([%e evar ("poly_"^name)] : Yojson.Safe.t -> _ error_or)]
   | { ptyp_desc = Ptyp_alias (typ, name) } ->
-    [%expr fun x -> [%e evar ("poly_"^name)] x; [%e desu_expr_of_typ ~path typ] x]
+    [%expr fun x -> [%e evar ("poly_"^name.txt)] x; [%e desu_expr_of_typ ~path typ] x]
   | { ptyp_desc = Ptyp_poly (names, typ) } ->
      poly_fun names (desu_expr_of_typ ~path typ)
   | { ptyp_loc } ->

--- a/src/ppx_deriving_yojson.ml
+++ b/src/ppx_deriving_yojson.ml
@@ -415,7 +415,7 @@ let ser_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
     in
     let ty = ser_type_of_decl ~options ~path type_decl in
     let fv = Ppx_deriving.free_vars_in_core_type ty in
-    let poly_type = Typ.force_poly @@ Typ.poly fv @@ ty in
+    let poly_type = Ast_builder.Default.ptyp_poly ~loc fv ty in
     let var_s = Ppx_deriving.mangle_type_decl (`Suffix "to_yojson") type_decl in
     let var = pvar var_s in
     ([],
@@ -629,7 +629,7 @@ let desu_str_of_type ~options ~path ({ ptype_loc = loc } as type_decl) =
     in
     let ty = desu_type_of_decl ~options ~path type_decl in
     let fv = Ppx_deriving.free_vars_in_core_type ty in
-    let poly_type = Typ.force_poly @@ Typ.poly fv @@ ty in
+    let poly_type = Ast_builder.Default.ptyp_poly ~loc fv ty in
     let var_s = Ppx_deriving.mangle_type_decl (`Suffix "of_yojson") type_decl in
     let var = pvar var_s in
     let var_s_exn = var_s ^ "_exn" in


### PR DESCRIPTION
This PR is a patch for an upcoming release of ppxlib where the internal AST is [bumped from 4.14 to 5.2](https://github.com/ocaml-ppx/ppxlib/pull/514). Until that is merged and released, there is no reason to merge this PR.

The most notable change is the representation of functions in the AST. 

### Functions
---

#### Currently 

In the parsetree currently, functions like:

```ocaml
fun x y z -> ...
```

Are represented roughly as

```ocaml
Pexp_fun(x, Pexp_fun (y, Pexp_fun(z, ...)))
```

Functions like:

```ocaml
function A -> ... | B -> ...
```

Are represented roughly as

```ocaml
Pexp_function ([ case A; case B ])
```

#### Since 5.2

All of these functions now map to a single AST node `Pexp_function` (note, this is the same name as the old cases function). The first argument is a list of parameters meaning:

```ocaml
fun x y z -> ...
```

Now looks like:

```ocaml
Pexp_function([x; y; z], _constraint, body)
```

And the `body` is where we can either have _more_ expressions (`Pfunction_body _`) or cases (`Pfunction_cases _`). That means:

```ocaml
function A -> ... | B -> ...
```

Has an empty list of parameters:

```ocaml
Pexp_function([], _, Pfunction_cases ([case A; case B]))
```

### Local Module Opens for Types
---

Another feature added in 5.2 was the ability to locally open modules in type definitions. 

```ocaml
module M = struct
  type t = A | B | C
end

type t = Local_open_coming of M.(t)
```

This has a `Ptyp_open (module_identifier, core_type)` AST node. Just like normal module opens this does create some syntactic ambiguity about where things come from inside the parentheses. The approach of these patches is to locally open the same module in any code that is generated.

This PR assumes `ppxlib.0.35.0` will be the ppxlib that contains the 5.2 AST bump. `ppxlib.0.34.0` will likely be the stable release of ppxlib with 5.3 support. This definitely might change, and the PR should be updated accordingly.