### PR TITLE
Fix generation of unnecessary Ptyp_poly nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 unreleased
 ----------
 
+  * Fix generation of unnecessary `Poly_typ ([], ...)` nodes when deriving
+    de/serializer for open types. These are rejected by OCaml 5.3 onward.
+    (#162)
+    @NathanReb
+
 3.9.0
 -----
 

--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -358,6 +358,8 @@ let test_opentype _ctxt =
   assert_roundtrip pp_ot to_yojson of_yojson
                    (C (Opentype.A 42, 1.2)) "[\"C\", [\"A\", 42], 1.2]"
 
+type paramless_opentype = .. [@@deriving yojson]
+
 
 (* This will fail at type-check if we introduce features that increase
    the default generated signatures. It is representative of user code


### PR DESCRIPTION
Fixes #161 

The deriver would always generate `Ptyp_poly` nodes, regardless of whether the type had parameters or not. We used to get away with it but starting with OCaml 5.3, the compiler now enforce this AST invariant that we were breaking.

