### PR TITLE
Make tests compatible with Yojson 3

### DIFF
--- a/src_test/test_ppx_yojson.ml
+++ b/src_test/test_ppx_yojson.ml
@@ -1,17 +1,7 @@
 open OUnit2
 
-type json =
-  [ `Assoc of (string * json) list
-  | `Bool of bool
-  | `Float of float
-  | `Int of int
-  | `Intlit of string
-  | `List of json list
-  | `Null
-  | `String of string
-  | `Tuple of json list
-  | `Variant of string * json option ]
-  [@@deriving show]
+let show_json = Yojson.Safe.show
+let pp_json = Yojson.Safe.pp
 
 let show_error_or =
   let module M = struct


### PR DESCRIPTION
Yojson 3 is being released which removes `Tuple` and `Variant`: https://github.com/ocaml/opam-repository/pull/27956

`ppx_deriving_yojson` doesn't really use them except for where it redefines `Yojson.Safe.t` to derive `show`. However, `show` and `pp` are already implemented upstream since Yojson 1.6.0, so there is no need for the redefinition.

This PR updates the tests so they work for the whole range of Yojson versions.